### PR TITLE
Possible fix for BoboTiG/python-mss#14

### DIFF
--- a/mss/darwin.py
+++ b/mss/darwin.py
@@ -139,11 +139,11 @@ class MSS(MSSBase):
 
         return self.monitors
 
-    def crop_width(self, image, width_from, width_to, height):
+    def crop_width(self, image, width_to):
         ''' Cut off the pixels from an image buffer at a particular width. '''
         cropped = bytearray()
-        for y in range(height):
-            start = y * width_from * 3
+        for row in range(self.height):
+            start = row * self.width * 3
             end = start + width_to * 3
             cropped.extend(image[start:end])
         return cropped
@@ -177,6 +177,6 @@ class MSS(MSSBase):
         self.core.CGDataProviderRelease(prov)
         self.image = self.bgra_to_rgb(bytearray(data.contents))
         if rounded_width != monitor['width']:
-            self.image = self.crop_width(self.image, rounded_width, self.width, self.height)
-        self.width = rounded_width
+            self.image = self.crop_width(self.image, monitor['width'])
+            self.width = monitor['width']
         return self.image

--- a/mss/darwin.py
+++ b/mss/darwin.py
@@ -11,6 +11,7 @@ from ctypes import (
     c_void_p, cast, cdll)
 from ctypes.util import find_library
 from sys import maxsize
+from math import ceil
 
 from .base import MSSBase
 from .exception import ScreenshotError
@@ -138,11 +139,28 @@ class MSS(MSSBase):
 
         return self.monitors
 
+    def crop_width(self, image, width_from, width_to, height):
+        ''' Cut off the pixels from an image buffer at a particular width. '''
+        cropped = bytearray()
+        for y in range(height):
+            start = y * width_from * 3
+            end = start + width_to * 3
+            cropped.extend(image[start:end])
+        return cropped
+
     def get_pixels(self, monitor):
         ''' Retrieve all pixels from a monitor. Pixels have to be RGB. '''
 
+        # When the monitor width is not divisible by 16, extra padding is
+        # added by MacOS in the form of black pixels, which results
+        # in a screenshot with shifted pixels.
+        # To counter this, we round the width to the nearest integer
+        # divisible by 16, and we remove the extra width from the
+        # image after taking the screenshot.
+        rounded_width = ceil(monitor['width'] / 16) * 16
+
         rect = CGRect((monitor['left'], monitor['top']),
-                      (monitor['width'], monitor['height']))
+                      (rounded_width, monitor['height']))
 
         image_ref = self.core.CGWindowListCreateImage(rect, 1, 0, 0)
         if not image_ref:
@@ -158,4 +176,7 @@ class MSS(MSSBase):
         data = cast(data_ref, POINTER(c_ubyte * buf_len))
         self.core.CGDataProviderRelease(prov)
         self.image = self.bgra_to_rgb(bytearray(data.contents))
+        if rounded_width != monitor['width']:
+            self.image = self.crop_width(self.image, rounded_width, self.width, self.height)
+        self.width = rounded_width
         return self.image


### PR DESCRIPTION
### Changes proposed in this PR
-  Possible fix for #14 
macOS seems to add extra padding in form of black pixels until the width is divisible by 16, this currently can result in a skewed image.
As a solution the image width is rounded up to the next multiple of 16, so we're taking a bigger screenshot than needed and crop it back to its original size afterwards.
Doing it this way doesn't remove important data in case the padding doesn't happen every time or changes in the future.
- An import for `ceil()` has been added in order to easily round up to the next multiple of 16

### Notes
- You should still test this on other machines if possible, since all of this was tested on a single macOS device running Sierra 10.12.4
- I didn't test how these changes impact performance, but it should be negligible and it fixes a pretty important bug
- @redodo helped me figure out much of the proposed solution

- [X] PEP8 compliant