### PR TITLE
tests: fix a ResourceWarning: unclosed file

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ History:
 
 3.3.0   2018/08/xx
       - Linux: add an error handler for the XServer to prevent interpreter crash (fix #61)
+      - tests: fix a ResourceWarning: unclosed file
       - big code clean-up using black
 
 3.2.1   2018/05/21

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,4 +53,5 @@ def is_travis():
 
 @pytest.fixture(scope="session")
 def raw():
-    return open("tests/res/monitor-1024x768.raw", "rb").read()
+    with open("tests/res/monitor-1024x768.raw", "rb") as f:
+        yield f.read()


### PR DESCRIPTION
Fixed a ResourceWarning:
```python
tests/test_bgra_to_rgb.py::test_good_types
  tests/conftest.py:56: ResourceWarning: unclosed file <_io.BufferedReader name='tests/res/monitor-1024x768.raw'>
    return open("tests/res/monitor-1024x768.raw", "rb").read()
```