### PR TITLE
fixes typo in pixel() method

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -112,7 +112,7 @@ Methods
 
         Instantiate a new class given only screen shot's data and size.
 
-    .. method:: pixels(coord_x, coord_y)
+    .. method:: pixel(coord_x, coord_y)
 
         :param int coord_x: The x coordinate.
         :param int coord_y: The y coordinate.


### PR DESCRIPTION
Caused overlap with the pixels property

### Changes proposed in this PR

- Change to documentation

- [x] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
