### PR TITLE
Test on Python 3.7 instead of 3.7-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,14 @@ python:
   - 2.7
   - 3.5
   - 3.6
-  - 3.7-dev
   - nightly # currently points to 3.8-dev
+
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 addons:
   apt:

--- a/docs/source/examples/callback.py
+++ b/docs/source/examples/callback.py
@@ -20,7 +20,7 @@ def on_exists(fname):
 
     if os.path.isfile(fname):
         newfile = fname + ".old"
-        print("{0} -> {1}".format(fname, newfile))
+        print("{} -> {}".format(fname, newfile))
         os.rename(fname, newfile)
 
 

--- a/docs/source/examples/opencv_numpy.py
+++ b/docs/source/examples/opencv_numpy.py
@@ -30,7 +30,7 @@ with mss.mss() as sct:
         # cv2.imshow('OpenCV/Numpy grayscale',
         #            cv2.cvtColor(img, cv2.COLOR_BGRA2GRAY))
 
-        print("fps: {0}".format(1 / (time.time() - last_time)))
+        print("fps: {}".format(1 / (time.time() - last_time)))
 
         # Press "q" to quit
         if cv2.waitKey(25) & 0xFF == ord("q"):

--- a/docs/source/examples/pil.py
+++ b/docs/source/examples/pil.py
@@ -22,6 +22,6 @@ with mss.mss() as sct:
         # img = Image.frombytes('RGB', sct_img.size, sct_img.rgb)
 
         # And save it!
-        output = "monitor-{0}.png".format(num)
+        output = "monitor-{}.png".format(num)
         img.save(output)
         print(output)

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -4,7 +4,7 @@ Support
 
 Feel free to try MSS on a system we had not tested, and let report us by creating an `issue <htps://github.com/BoboTiG/python-mss/issues>`_.
 
-GNU/Linux, macOS and Windows: **2.7**, 3.5, **3.6** and 3.7-dev.
+GNU/Linux, macOS and Windows: **2.7**, 3.5, 3.6 and **3.7**.
 
 
 Future

--- a/mss/base.py
+++ b/mss/base.py
@@ -116,7 +116,7 @@ class MSSBase(object):
             try:
                 monitor = monitors[mon]
             except IndexError:
-                raise ScreenShotError("Monitor {0!r} does not exist.".format(mon))
+                raise ScreenShotError("Monitor {!r} does not exist.".format(mon))
 
             output = output.format(mon=mon, date=datetime.now(), **monitor)
             if callable(callback):

--- a/mss/darwin.py
+++ b/mss/darwin.py
@@ -32,7 +32,7 @@ class CGPoint(ctypes.Structure):
     _fields_ = [("x", cgfloat()), ("y", cgfloat())]
 
     def __repr__(self):
-        return "{0}(left={1} top={2})".format(type(self).__name__, self.x, self.y)
+        return "{}(left={} top={})".format(type(self).__name__, self.x, self.y)
 
 
 class CGSize(ctypes.Structure):
@@ -41,7 +41,7 @@ class CGSize(ctypes.Structure):
     _fields_ = [("width", cgfloat()), ("height", cgfloat())]
 
     def __repr__(self):
-        return "{0}(width={1} height={2})".format(
+        return "{}(width={} height={})".format(
             type(self).__name__, self.width, self.height
         )
 
@@ -52,7 +52,7 @@ class CGRect(ctypes.Structure):
     _fields_ = [("origin", CGPoint), ("size", CGSize)]
 
     def __repr__(self):
-        return "{0}<{1} {2}>".format(type(self).__name__, self.origin, self.size)
+        return "{}<{} {}>".format(type(self).__name__, self.origin, self.size)
 
 
 class MSS(MSSBase):

--- a/mss/factory.py
+++ b/mss/factory.py
@@ -30,7 +30,7 @@ def mss(**kwargs):
         from .windows import MSS
     else:
         raise ScreenShotError(
-            "System {0!r} not (yet?) implemented.".format(operating_system)
+            "System {!r} not (yet?) implemented.".format(operating_system)
         )
 
     return MSS(**kwargs)

--- a/mss/linux.py
+++ b/mss/linux.py
@@ -170,7 +170,7 @@ class MSS(MSSBase):
             display = display.encode("utf-8")
 
         if b":" not in display:
-            raise ScreenShotError("Bad display value: {0!r}.".format(display))
+            raise ScreenShotError("Bad display value: {!r}.".format(display))
 
         x11 = ctypes.util.find_library("X11")
         if not x11:
@@ -313,7 +313,7 @@ class MSS(MSSBase):
             if retval != 0 and not MSS.last_error:
                 return args
 
-            err = "{0}() failed".format(func.__name__)
+            err = "{}() failed".format(func.__name__)
             details = {"retval": retval, "args": args}
 
             if MSS.last_error:
@@ -329,7 +329,7 @@ class MSS(MSSBase):
                 xerror = xserver_error.value.decode("utf-8")
                 if xerror != "0":
                     details["xerror"] = xerror
-                    err += ": {0}".format(xerror)
+                    err += ": {}".format(xerror)
 
             raise ScreenShotError(err, details=details)
 
@@ -407,7 +407,7 @@ class MSS(MSSBase):
         bits_per_pixel = ximage.contents.bits_per_pixel
         if bits_per_pixel != 32:
             raise ScreenShotError(
-                "[XImage] bits per pixel value not (yet?) implemented: {0}.".format(
+                "[XImage] bits per pixel value not (yet?) implemented: {}.".format(
                     bits_per_pixel
                 )
             )

--- a/mss/screenshot.py
+++ b/mss/screenshot.py
@@ -149,5 +149,5 @@ class ScreenShot(object):
             return self.pixels[coord_y][coord_x]
         except IndexError:
             raise ScreenShotError(
-                "Pixel location ({0}, {1}) is out of range.".format(coord_x, coord_y)
+                "Pixel location ({}, {}) is out of range.".format(coord_x, coord_y)
             )

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ classifiers = [
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.4",
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ config = {
         "in pure python using ctypes."
     ),
     "long_description": description,
+    "python_requires": ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     "classifiers": classifiers,
     "platforms": ["Darwin", "Linux", "Windows"],
     "packages": ["mss"],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,11 @@ def purge_files():
     """ Remove all generated files from previous runs. """
 
     for fname in glob.glob("*.png"):
-        print("Deleting {0!r} ...".format(fname))
+        print("Deleting {!r} ...".format(fname))
         os.unlink(fname)
 
     for fname in glob.glob("*.png.old"):
-        print("Deleting {0!r} ...".format(fname))
+        print("Deleting {!r} ...".format(fname))
         os.unlink(fname)
 
 


### PR DESCRIPTION
### Changes proposed in this PR

- Test on Python 3.7, requires a small workaround: https://github.com/travis-ci/travis-ci/issues/9815
- Remove testing on 3.7-dev
- Remove already dropped 3.4 from classifiers
- Add python_requires to help pip

It is **very** important to keep up to date tests and documentation.

- [x] Tests added/updated
- [x] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
