### PR TITLE
fix issue #79: do monitor detection in MSS constructor

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,9 @@
 Alexander 'thehesiod' Mohr [https://github.com/thehesiod]
     - Windows: robustness to MSS.get_pixels()
 
+Andreas Buhr [https://www.andreasbuhr.de]
+    - Bugfix for multi-monitor detection
+
 bubulle [http://indexerror.net/user/bubulle]
     - Windows: efficiency of MSS.get_pixels()
 

--- a/mss/base.py
+++ b/mss/base.py
@@ -16,7 +16,6 @@ class MSSBase(object):
 
     cls_image = ScreenShot  # type: object
     compression_level = 6  # type: int
-    _monitors = []  # type: List[Dict[str, int]]
 
     def __enter__(self):
         # type: () -> MSSBase

--- a/mss/darwin.py
+++ b/mss/darwin.py
@@ -67,6 +67,8 @@ class MSS(MSSBase):
         # type: () -> None
         """ macOS initialisations. """
 
+        self._monitors = []  # type: List[Dict[str, int]]
+
         coregraphics = ctypes.util.find_library("CoreGraphics")
         if not coregraphics:
             raise ScreenShotError("No CoreGraphics library found.")

--- a/mss/linux.py
+++ b/mss/linux.py
@@ -160,6 +160,8 @@ class MSS(MSSBase):
         # type: (bytes) -> None
         """ GNU/Linux initialisations. """
 
+        self._monitors = []  # type: List[Dict[str, int]]
+
         if not display:
             try:
                 display = os.environ["DISPLAY"].encode("utf-8")

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -62,6 +62,8 @@ class MSS(MSSBase):
         # type: () -> None
         """ Windows initialisations. """
 
+        self._monitors = []  # type: List[Dict[str, int]]
+
         self.monitorenumproc = ctypes.WINFUNCTYPE(
             ctypes.wintypes.INT,
             ctypes.wintypes.DWORD,

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -114,7 +114,7 @@ def test_entry_point(capsys, sct):
 
     fmt = "sct_{mon}-{date:%Y-%m-%d}.png"
     for opt in ("-o", "--out"):
-        main([opt, fmt])
+        main(["-m 1", opt, fmt])
         filename = fmt.format(mon=1, date=datetime.now())
         out, _ = capsys.readouterr()
         assert out.endswith(filename + "\n")


### PR DESCRIPTION
### Changes proposed in this PR

The variable MSSBase._monitors was a class variable, so the monitor detection was only done once per interpreter run. So when changing the monitor configuration during a script run, the subsequent screenshots were wrong.

This pull request changes "_monitors" from being a class variable of MSSBase to be a member variable of MSS. The different MSS constructors initialize it.

It would have been nice to initialize "_monitors" in MSSBase, but the constructors of the different MSS classes do not call the super-constructor, so this is not an option.

Another possible fix would have been to reset "_monitors" in MSSBase.__exit__, but that could lead to a race condition in threaded environments: Thread A checking for "_monitors", then thread B calling an "__exit__", then thread A using "_monitors". This fix has no race condition.

Along the way, a bug was found in the unit tests when executed on a multi-monitor environment. This bug was also fixed.


- Fixes #79 

Test were not added as I have no idea how to test this, you cannot change the number of monitors in a unit test.

The documentation was not updated, as this was a bug and the intended behaviour did not change.

Code passes flake8.