### PR TITLE
Drop support for legacy Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: xenial
 
 matrix:
   include:
+    - os: linux
+      python: "3.7"
+      env: TOXENV=lint
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,8 @@
 language: python
 dist: xenial
-sudo: true
 
 matrix:
   include:
-    - os: linux
-      python: "2.7"
-      env:
-        - TOXENV=py27
     - os: linux
       python: "3.5"
       env: TOXENV=py35
@@ -20,11 +15,6 @@ matrix:
     - os: linux
       python: "pypy3.5"
       env: TOXENV=pypy3
-    - os: osx
-      language: generic
-      env:
-        - PYTHON_VERSION=2.7
-        - TOXENV=py27
     - os: osx
       language: generic
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ dist: xenial
 
 matrix:
   include:
+    - os: osx
+      language: generic
+      env:
+        - PYTHON_VERSION=3.7
+        - TOXENV=py37
     - os: linux
       python: "3.5"
       env: TOXENV=py35
@@ -15,11 +20,6 @@ matrix:
     - os: linux
       python: "pypy3.5"
       env: TOXENV=pypy3
-    - os: osx
-      language: generic
-      env:
-        - PYTHON_VERSION=3.7
-        - TOXENV=py37
 
 addons:
   apt:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,22 +1,13 @@
 #!/bin/bash
 # Taken largely from https://stackoverflow.com/q/45257534
-if [[ "$PYTHON_VERSION" == "2.7" ]]; then
-    which virtualenv
-    # Create and activate a virtualenv for conda
-    virtualenv -p python condavenv
-    source condavenv/bin/activate
-    # Grab Miniconda 2
-    wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh
-else
-    # Install or upgrade to Python 3
-    brew update 1>/dev/null
-    brew upgrade python
-    # Create and activate a virtualenv for conda
-    virtualenv -p python3 condavenv
-    source condavenv/bin/activate
-    # Grab Miniconda 3
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
-fi
+# Install or upgrade to Python 3
+brew update 1>/dev/null
+brew upgrade python
+# Create and activate a virtualenv for conda
+virtualenv -p python3 condavenv
+source condavenv/bin/activate
+# Grab Miniconda 3
+wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh
 
 # Install our version of miniconda
 bash miniconda.sh -b -p $HOME/miniconda

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,12 +6,6 @@ cache:
 environment:
   fast_finish: true
   matrix:
-    - python: py27
-      tox_env: py27
-      python_path: c:\python27
-    - python: py27-x64
-      tox_env: py27
-      python_path: c:\python27-x64
     - python: py35
       tox_env: py35
       python_path: c:\python35

--- a/docs/source/examples/custom_cls_image.py
+++ b/docs/source/examples/custom_cls_image.py
@@ -9,7 +9,7 @@ Screenshot of the monitor 1, using a custom class to handle the data.
 import mss
 
 
-class SimpleScreenShot(object):
+class SimpleScreenShot:
     """
     Define your own custom method to deal with screen shot raw data.
     Of course, you can inherit from the ScreenShot class and change

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -2,10 +2,10 @@
 Support
 =======
 
-Feel free to try MSS on a system we had not tested, and let report us by creating an `issue <htps://github.com/BoboTiG/python-mss/issues>`_.
+Feel free to try MSS on a system we had not tested, and let us know by creating an `issue <https://github.com/BoboTiG/python-mss/issues>`_.
 
     - OS: GNU/Linux, macOS and Windows
-    - Python: 2.7, 3.5, 3.6 and **3.7**
+    - Python: 3.5, 3.6 and **3.7**
 
 
 Future
@@ -25,6 +25,7 @@ Abandoned
 =========
 
 - Python 2.6 (2016-10-08)
+- Python 2.7 (2019-XX-XX)
 - Python 3.0 (2016-10-08)
 - Python 3.1 (2016-10-08)
 - Python 3.2 (2016-10-08)

--- a/mss/base.py
+++ b/mss/base.py
@@ -11,7 +11,7 @@ from .screenshot import ScreenShot
 from .tools import to_png
 
 
-class MSSMixin(object):
+class MSSMixin:
     """ This class will be overloaded by a system specific one. """
 
     cls_image = ScreenShot  # type: object

--- a/mss/exception.py
+++ b/mss/exception.py
@@ -10,5 +10,5 @@ class ScreenShotError(Exception):
 
     def __init__(self, message, details=None):
         # type: (Dict[str, Any]) -> None
-        super(ScreenShotError, self).__init__(message)
+        super().__init__(message)
         self.details = details or {}

--- a/mss/screenshot.py
+++ b/mss/screenshot.py
@@ -13,7 +13,7 @@ Pos = collections.namedtuple("Pos", "left, top")
 Size = collections.namedtuple("Size", "width, height")
 
 
-class ScreenShot(object):
+class ScreenShot:
     """
     Screen shot object.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,12 +15,11 @@ classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3 :: Only
     Topic :: Multimedia :: Graphics :: Capture :: Screen Capture
     Topic :: Software Development :: Libraries
 
@@ -28,7 +27,7 @@ classifiers =
 zip-safe = False
 include_package_data = True
 packages = mss
-python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
+python_requires = >=3.5
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_cls_image.py
+++ b/tests/test_cls_image.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 
-class SimpleScreenShot(object):
+class SimpleScreenShot:
     def __init__(self, data, monitor, **kwargs):
         self.raw = bytes(data)
         self.monitor = monitor

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,36,35,27,py3,py},docs
+envlist = py{37,36,35,py3},docs
 skip_missing_interpreters = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,8 @@
 [tox]
-envlist = py{37,36,35,py3},docs
+envlist =
+    lint
+    py{37,36,35,py3}
+    docs
 skip_missing_interpreters = True
 
 [testenv]
@@ -7,12 +10,16 @@ passenv = DISPLAY
 alwayscopy = True
 deps =
     pytest>=4.0.2
-    flake8>=3.6.0
     numpy==1.15.4
     py37: pillow>=5.4.0
 commands =
     python -m pytest {posargs}
-    py3{7,6,5,}: python -m flake8 docs mss tests
+
+[testenv:lint]
+deps =
+    flake8>=3.6.0
+commands =
+    python -m flake8 docs mss tests
 
 [testenv:docs]
 description = build the documentation


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes #94
- Drop support for legacy Python 2.7
- Extract `flake8` to own Tox task for visibility and so failures don't cause other jobs to fail. Put this first for fast feedback.
- Run slow Mac build second to make full use of parallel builds, reduce bottleneck and reduce waiting.


It is **very** important to keep up to date tests and documentation.

- [n/a] Tests added/updated
- [x] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [ ] `flake8` passed: master is failing, as there's a new release of `flake8` and `pyflakes` that now checks typing comments too.
