### PR TITLE
Ignore missing SetProcessDPIAware on WinXP

### DIFF
--- a/mss/windows.py
+++ b/mss/windows.py
@@ -95,7 +95,7 @@ class MSS(MSSMixin):
             try:
                 self.user32.SetProcessDPIAware()
             except AttributeError:
-                pass # Windows XP doesn't have SetProcessDPIAware
+                pass  # Windows XP doesn't have SetProcessDPIAware
 
         self._srcdc = self.user32.GetWindowDC(0)
         self._memdc = self.gdi32.CreateCompatibleDC(self._srcdc)

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -92,7 +92,10 @@ class MSS(MSSMixin):
                 self.user32.PROCESS_PER_MONITOR_DPI_AWARE
             )
         except AttributeError:
-            self.user32.SetProcessDPIAware()
+            try:
+                self.user32.SetProcessDPIAware()
+            except AttributeError:
+                pass # Windows XP doesn't have SetProcessDPIAware
 
         self._srcdc = self.user32.GetWindowDC(0)
         self._memdc = self.gdi32.CreateCompatibleDC(self._srcdc)


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes #109

Is your code right?

- [✓] PEP8 compliant
- [✓] `flake8` passed
