### PR TITLE
Windows DPI bugfix

### DIFF
--- a/mss/windows.py
+++ b/mss/windows.py
@@ -198,9 +198,11 @@ class MSS(MSSMixin):
         """
 
         release = int(platform.win32_ver()[0])
-        if release >= 8: #windows 10 and 8
+        #windows 10 and 8
+        if release >= 8: 
             ctypes.windll.shcore.SetProcessDpiAwareness(2)
-        elif release >= 6 and release < 8: #windows 6(vista) and 7
+        #windows 6(vista) and 7
+        if release >= 6 and release < 8:
             ctypes.windll.user32.SetProcessDPIAware() 
 
 


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes #
- Changed SetProcessDpiAwareness attribute call on window 8+ to correct one
- Changed logic to if statements instead of wrapping everything in exeptions
- Put code in a separate method instead of calling from __init__ method.(I really spent a long time trying
to understand what's wrong because the code which is related to the problem has no logical relationships with monitor method. If not fot the comments I wouldn't find the bug)
