### PR TITLE
Tests: Add Python 3.8 to the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,32 +4,66 @@ dist: xenial
 matrix:
   fast_finish: true
   include:
-    - os: linux
-      python: "3.7"
+    - name: Code quality checks
+      os: linux
+      python: "3.8"
       env: TOXENV=lint
-    - os: linux
-      python: "3.7"
+    - name: Types checking
+      os: linux
+      python: "3.8"
       env: TOXENV=types
-    - os: linux
-      python: "3.7"
+    - name: Documentation build
+      os: linux
+      python: "3.8"
       env: TOXENV=docs
     - os: osx
-      language: generic
+      language: shell
+      before_install:
+        - bash .travis/install.sh
+      env:
+        - PYTHON_VERSION=3.5
+        - TOXENV=py35
+    - name: "Python 3.6 on macOS 10.13"
+      os: osx
+      osx_image: xcode9.4  # Python 3.6.5 running on macOS 10.13
+      language: shell
+      env:
+        - PYTHON_VERSION=3.6
+        - TOXENV=py36
+    - name: "Python 3.7 on macOS 10.14"
+      os: osx
+      osx_image: xcode10.2  # Python 3.7.3 running on macOS 10.14.3
+      language: shell
       env:
         - PYTHON_VERSION=3.7
         - TOXENV=py37
-    - os: linux
+    - os: osx
+      language: shell
+      before_install:
+        - bash .travis/install.sh
+      env:
+        - PYTHON_VERSION=3.8
+        - TOXENV=py38
+    - name: "PyPy 3.6 on GNU/Linux"
+      os: linux
+      python: "pypy3"
+      env: TOXENV=pypy3
+    - name: "Python 3.5 on GNU/Linux"
+      os: linux
       python: "3.5"
       env: TOXENV=py35
-    - os: linux
+    - name: "Python 3.6 on GNU/Linux"
+      os: linux
       python: "3.6"
       env: TOXENV=py36
-    - os: linux
+    - name: "Python 3.7 on GNU/Linux"
+      os: linux
       python: "3.7"
       env: TOXENV=py37
-    - os: linux
-      python: "pypy3.5"
-      env: TOXENV=pypy3
+    - name: "Python 3.8 on GNU/Linux"
+      os: linux
+      python: "3.8"
+      env: TOXENV=py38
 
 addons:
   apt:
@@ -38,9 +72,6 @@ addons:
 
 services:
   - xvfb
-
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then bash .travis/install.sh; fi
 
 install:
   - python -m pip install --upgrade pip tox

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,8 @@ Python MSS
 
 .. image:: https://travis-ci.org/BoboTiG/python-mss.svg?branch=master
     :target: https://travis-ci.org/BoboTiG/python-mss
+.. image:: https://ci.appveyor.com/api/projects/status/72dik18r6b746mb0?svg=true
+    :target: https://ci.appveyor.com/project/BoboTiG/python-mss
 .. image:: https://img.shields.io/badge/say-thanks-ff69b4.svg
     :target: https://saythanks.io/to/BoboTiG
 .. image:: https://pepy.tech/badge/mss

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,12 @@ environment:
     - python: py37-x64
       tox_env: py37
       python_path: c:\python37-x64
+    - python: py38
+      tox_env: py38
+      python_path: c:\python38
+    - python: py38-x64
+      tox_env: py38
+      python_path: c:\python38-x64
 
 install:
   - python -m pip install virtualenv

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3 :: Only
     Topic :: Multimedia :: Graphics :: Capture :: Screen Capture
     Topic :: Software Development :: Libraries

--- a/tox.ini
+++ b/tox.ini
@@ -3,23 +3,24 @@ envlist =
     lint
     types
     docs
-    py{37,36,35,py3}
+    py{38,37,36,35,py3}
 skip_missing_interpreters = True
 
 [testenv]
 passenv = DISPLAY
 alwayscopy = True
 deps =
-    pytest>=4.0.2
+    pytest
+    # Must pin that version to support PyPy3
     numpy==1.15.4
-    py37: pillow>=5.4.0
+    pillow
 commands =
     python -m pytest {posargs}
 
 [testenv:lint]
 description = Code quality check
 deps =
-    flake8>=3.6.0
+    flake8
     pylint
 commands =
     python -m flake8 docs mss tests


### PR DESCRIPTION
- Exanded the tests matrix: PyPy 3.6, Python 3.5 and 3.6 on macOS.
- Arranged the tests matrix to run macOS tests first as they tend to take way more time.
- Use Python 3.8 for lint, types and docs tox env.
- Added the Python 3.8 classifier.
- Added the AppVeyor badge on the README.