### PR TITLE
Windows: fix region caching that resulted in bad captures

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ History:
 
 <see Git checking messages for history>
 
+5.0.1   2020/xx/xx
+      - Windows: fix region caching that resulted in bad captures
+
 5.0.0   2019/12/31
       - removed support for Python 2.7
       - MSS: improve type annotations and add CI check


### PR DESCRIPTION
On Windows, the grabbed region is cached to prevent useless resources allocations and speed-up further calls to `.grab()`.

But the check to decide if the cached region needs an update was comparing sizes only. And using same region sizes with different region positions between 2 calls to `.grab()` were resulting in bad screenshots.