### PR TITLE
Revert "Windows: fix region caching that resulted in bad captures"

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,9 +2,6 @@ History:
 
 <see Git checking messages for history>
 
-5.0.1   2020/xx/xx
-      - Windows: fix region caching that resulted in bad captures
-
 5.0.0   2019/12/31
       - removed support for Python 2.7
       - MSS: improve type annotations and add CI check

--- a/mss/tests/test_windows.py
+++ b/mss/tests/test_windows.py
@@ -40,10 +40,10 @@ def test_region_caching():
         sct.grab(region1)
         bmp1 = MSS.bmp
 
-        # Grab the area 2, the cached BMP is updated
+        # Grab the area 2, the cached BMP is used
         sct.grab(region2)
         bmp2 = MSS.bmp
-        assert bmp1 is not bmp2
+        assert bmp1 is bmp2
 
         # Grab the area 2 again, the cached BMP is used
         sct.grab(region2)

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -26,7 +26,7 @@ from .base import MSSMixin
 from .exception import ScreenShotError
 
 if TYPE_CHECKING:
-    from typing import Any, Dict  # noqa
+    from typing import Any  # noqa
 
     from .models import Monitor, Monitors  # noqa
     from .screenshot import ScreenShot  # noqa
@@ -90,7 +90,7 @@ class MSS(MSSMixin):
         self._set_cfunctions()
         self._set_dpi_awareness()
 
-        self._bbox = {}  # type: Dict[str, int]
+        self._bbox = {"height": 0, "width": 0}
         self._data = ctypes.create_string_buffer(0)  # type: ctypes.Array[ctypes.c_char]
 
         if not MSS.srcdc or not MSS.memdc:
@@ -263,7 +263,8 @@ class MSS(MSSMixin):
         srcdc, memdc = MSS.srcdc, MSS.memdc
         width, height = monitor["width"], monitor["height"]
 
-        if self._bbox != monitor:
+        if (self._bbox["height"], self._bbox["width"]) != (height, width):
+            self._bbox = monitor
             self._bmi.bmiHeader.biWidth = width
             self._bmi.bmiHeader.biHeight = -height  # Why minus? [1]
             self._data = ctypes.create_string_buffer(width * height * 4)  # [2]
@@ -271,7 +272,6 @@ class MSS(MSSMixin):
                 self.gdi32.DeleteObject(MSS.bmp)
             MSS.bmp = self.gdi32.CreateCompatibleBitmap(srcdc, width, height)
             self.gdi32.SelectObject(memdc, MSS.bmp)
-            self._bbox = monitor
 
         self.gdi32.BitBlt(
             memdc,


### PR DESCRIPTION
This reverts commit 5e5f3eecc87660b73d11c4c964571f1515c09531.

The patch was indeed a bad idea and fixed nothing ...
I reverted it but kept the test.