### PR TITLE
dev: produce wheels for Python 3 only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ build/
 dist/
 *.egg-info/
 .idea/
-MANIFEST*
 .DS_Store
 *.orig
 *.jpg

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@ History:
 
 <see Git checking messages for history>
 
+5.0.1   2020/xx/xx
+      - produce wheels for Python 3 only
+
 5.0.0   2019/12/31
       - removed support for Python 2.7
       - MSS: improve type annotations and add CI check

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# Include tests files and data
+include mss/tests/*.py
+recursive-include mss/tests/res *

--- a/mss/tests/test_setup.py
+++ b/mss/tests/test_setup.py
@@ -1,0 +1,17 @@
+"""
+This is part of the MSS Python's module.
+Source: https://github.com/BoboTiG/python-mss
+"""
+
+from subprocess import check_output
+
+from mss import __version__
+
+CMD = "python setup.py sdist bdist_wheel".split()
+
+
+def test_wheel_python_3_only():
+    """Ensure the produced wheel is Python 3 only."""
+    output = str(check_output(CMD))
+    text = "mss-{}-py3-none-any.whl".format(__version__)
+    assert text in output

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,17 +31,12 @@ classifiers =
 [options]
 zip-safe = False
 include_package_data = True
-packages =
-    mss
-    mss.tests
+packages = mss
 python_requires = >=3.5
 
 [options.entry_points]
 console_scripts =
     mss = mss.__main__:main
-
-[bdist_wheel]
-universal = 1
 
 [flake8]
 ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     # Must pin that version to support PyPy3
     numpy==1.15.4
     pillow
+    wheel
 commands =
     python -m pytest {posargs}
 


### PR DESCRIPTION
For instance, the version 5.0.0 shipped a wheel letting users know that Python 2 and 3 are supported.
This is not true for Python 2.

The patch will changes the wheel name: `mss-VERSION-py2.py3-none-any.whl` -> `mss-VERSION-py3-none-any.whl`