### PR TITLE
MSS: renamed again MSSMixin to MSSBase, now derived from abc.ABCMeta

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ History:
 
 5.0.1   2020/xx/xx
       - produce wheels for Python 3 only
+      - MSS: renamed again MSSMixin to MSSBase, now derived from abc.ABCMeta
       - tools: force write of file when saving a PNG file
       - tests: fix tests on macOS with Retina display
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,15 @@
-5.0.0 (2019-xx-xx)
+5.0.1 (2020-xx-xx)
+==================
+
+base.py
+-------
+- Renamed back ``MSSMixin`` class to ``MSSBase``
+- ``MSSBase`` is now derived from ``abc.ABCMeta``
+- ``MSSBase.monitor`` is now an abstract property
+- ``MSSBase.grab()`` is now an abstract method
+
+
+5.0.0 (2019-12-31)
 ==================
 
 darwin.py

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -59,7 +59,7 @@ GNU/Linux
         :rtype: :class:`~mss.base.ScreenShot`
         :raises ScreenShotError: When color depth is not 32 (rare).
 
-        See :meth:`~mss.base.MSSMixin.grab()` for details.
+        See :meth:`~mss.base.MSSBase.grab()` for details.
 
 .. function:: error_handler(display, event)
 
@@ -82,7 +82,7 @@ Methods
 
 .. module:: mss.base
 
-.. class:: MSSMixin
+.. class:: MSSBase
 
     The parent's class for every OS implementation.
 
@@ -96,9 +96,9 @@ Methods
 
         :param dict monitor: region's coordinates.
         :rtype: :class:`ScreenShot`
-        :raises NotImplementedError: Subclasses need to implement this.
 
         Retrieve screen pixels for a given *region*.
+        Subclasses need to implement this.
 
         .. note::
 
@@ -194,7 +194,7 @@ Methods
 Properties
 ==========
 
-.. class:: mss.base.MSSMixin
+.. class:: mss.base.MSSBase
 
     .. attribute:: monitors
 
@@ -214,6 +214,8 @@ Properties
         - ``top``: the y-coordinate of the upper-left corner
         - ``width``: the width
         - ``height``: the height
+
+        Subclasses need to implement this.
 
         :rtype:  list[dict[str, int]]
 

--- a/mss/base.py
+++ b/mss/base.py
@@ -3,6 +3,7 @@ This is part of the MSS Python's module.
 Source: https://github.com/BoboTiG/python-mss
 """
 
+from abc import ABCMeta, abstractmethod
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -16,7 +17,7 @@ if TYPE_CHECKING:
     from .models import Monitor, Monitors  # noqa
 
 
-class MSSMixin:
+class MSSBase(metaclass=ABCMeta):
     """ This class will be overloaded by a system specific one. """
 
     __slots__ = {"_monitors", "cls_image", "compression_level"}
@@ -27,7 +28,7 @@ class MSSMixin:
         self._monitors = []  # type: Monitors
 
     def __enter__(self):
-        # type: () -> MSSMixin
+        # type: () -> MSSBase
         """ For the cool call `with MSS() as mss:`. """
 
         return self
@@ -41,6 +42,7 @@ class MSSMixin:
         # type: () -> None
         """ Clean-up. """
 
+    @abstractmethod
     def grab(self, monitor):
         # type: (Monitor) -> ScreenShot
         """
@@ -51,9 +53,8 @@ class MSSMixin:
         :return :class:`ScreenShot <ScreenShot>`.
         """
 
-        raise NotImplementedError("Subclasses need to implement this!")
-
     @property
+    @abstractmethod
     def monitors(self):
         # type: () -> Monitors
         """

--- a/mss/darwin.py
+++ b/mss/darwin.py
@@ -8,7 +8,7 @@ import ctypes.util
 import sys
 from typing import TYPE_CHECKING
 
-from .base import MSSMixin
+from .base import MSSBase
 from .exception import ScreenShotError
 from .screenshot import Size
 
@@ -57,7 +57,7 @@ class CGRect(ctypes.Structure):
         return "{}<{} {}>".format(type(self).__name__, self.origin, self.size)
 
 
-class MSS(MSSMixin):
+class MSS(MSSBase):
     """
     Multiple ScreenShots implementation for macOS.
     It uses intensively the CoreGraphics library.
@@ -175,7 +175,7 @@ class MSS(MSSMixin):
     def grab(self, monitor):
         # type: (Monitor) -> ScreenShot
         """
-        See :meth:`MSSMixin.grab <mss.base.MSSMixin.grab>` for full details.
+        See :meth:`MSSBase.grab <mss.base.MSSBase.grab>` for full details.
         """
 
         # pylint: disable=too-many-locals

--- a/mss/factory.py
+++ b/mss/factory.py
@@ -12,11 +12,11 @@ from .exception import ScreenShotError
 if TYPE_CHECKING:
     from typing import Any  # noqa
 
-    from .base import MSSMixin  # noqa
+    from .base import MSSBase  # noqa
 
 
 def mss(**kwargs):
-    # type: (Any) -> MSSMixin
+    # type: (Any) -> MSSBase
     """ Factory returning a proper MSS class instance.
 
         It detects the plateform we are running on

--- a/mss/linux.py
+++ b/mss/linux.py
@@ -9,7 +9,7 @@ import os
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
-from .base import MSSMixin
+from .base import MSSBase
 from .exception import ScreenShotError
 
 if TYPE_CHECKING:
@@ -175,7 +175,7 @@ def validate(retval, func, args):
     raise ScreenShotError(err, details=details)
 
 
-class MSS(MSSMixin):
+class MSS(MSSBase):
     """
     Multiple ScreenShots implementation for GNU/Linux.
     It uses intensively the Xlib and its Xrandr extension.

--- a/mss/tests/test_gnu_linux.py
+++ b/mss/tests/test_gnu_linux.py
@@ -9,7 +9,7 @@ import platform
 
 import mss
 import pytest
-from mss.base import MSSMixin
+from mss.base import MSSBase
 from mss.exception import ScreenShotError
 
 
@@ -32,7 +32,7 @@ def test_factory_systems(monkeypatch):
     # GNU/Linux
     monkeypatch.setattr(platform, "system", lambda: "LINUX")
     with mss.mss() as sct:
-        assert isinstance(sct, MSSMixin)
+        assert isinstance(sct, MSSBase)
     monkeypatch.undo()
 
     # macOS

--- a/mss/tests/test_implementation.py
+++ b/mss/tests/test_implementation.py
@@ -6,59 +6,43 @@ Source: https://github.com/BoboTiG/python-mss
 import os
 import os.path
 import platform
-import sys
 
+import pytest
 import mss
 import mss.tools
-from mss.base import MSSMixin
+from mss.base import MSSBase
 from mss.exception import ScreenShotError
 from mss.screenshot import ScreenShot
 
-import pytest
 
-
-PY3 = sys.version[0] > "2"
-
-
-class MSS0(MSSMixin):
+class MSS0(MSSBase):
     """ Nothing implemented. """
 
     pass
 
 
-class MSS1(MSSMixin):
-    """ Emulate no monitors. """
+class MSS1(MSSBase):
+    """ Only `grab()` implemented. """
+
+    def grab(self, monitor):
+        pass
+
+
+class MSS2(MSSBase):
+    """ Only `monitor` implemented. """
 
     @property
     def monitors(self):
         return []
 
 
-class MSS2(MSSMixin):
-    """ Emulate one monitor. """
-
-    @property
-    def monitors(self):
-        return [{"top": 0, "left": 0, "width": 10, "height": 10}]
+@pytest.mark.parametrize("cls", [MSS0, MSS1, MSS2])
+def test_incomplete_class(cls):
+    with pytest.raises(TypeError):
+        cls()
 
 
-def test_incomplete_class():
-    # `monitors` property not implemented
-    with pytest.raises(NotImplementedError):
-        for filename in MSS0().save():
-            assert os.path.isfile(filename)
-
-    # `monitors` property is empty
-    with pytest.raises(ScreenShotError):
-        for filename in MSS1().save():
-            assert os.path.isfile(filename)
-
-    # `grab()` not implemented
-    sct = MSS2()
-    with pytest.raises(NotImplementedError):
-        sct.grab(sct.monitors[0])
-
-    # Bad monitor
+def test_bad_monitor(sct):
     with pytest.raises(ScreenShotError):
         sct.grab(sct.shot(mon=222))
 
@@ -79,7 +63,7 @@ def test_repr(sct, pixel_ratio):
 def test_factory(monkeypatch):
     # Current system
     with mss.mss() as sct:
-        assert isinstance(sct, MSSMixin)
+        assert isinstance(sct, MSSBase)
 
     # Unknown
     monkeypatch.setattr(platform, "system", lambda: "Chuck Norris")
@@ -87,10 +71,7 @@ def test_factory(monkeypatch):
         mss.mss()
     monkeypatch.undo()
 
-    if not PY3:
-        error = exc.value[0]
-    else:
-        error = exc.value.args[0]
+    error = exc.value.args[0]
     assert error == "System 'chuck norris' not (yet?) implemented."
 
 

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -22,7 +22,7 @@ from ctypes.wintypes import (
 )
 from typing import TYPE_CHECKING
 
-from .base import MSSMixin
+from .base import MSSBase
 from .exception import ScreenShotError
 
 if TYPE_CHECKING:
@@ -65,7 +65,7 @@ class BITMAPINFO(ctypes.Structure):
     _fields_ = [("bmiHeader", BITMAPINFOHEADER), ("bmiColors", DWORD * 3)]
 
 
-class MSS(MSSMixin):
+class MSS(MSSBase):
     """ Multiple ScreenShots implementation for Microsoft Windows. """
 
     __slots__ = {"_bbox", "_bmi", "_data", "gdi32", "monitorenumproc", "user32"}


### PR DESCRIPTION
- `MSSMixin` was really a base class, not a mixin.
- Correctly implemented abstract attributes.