### PR TITLE
Windows: fix multi-thread unsafe and update test

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,8 @@ History:
       - MSS: renamed again MSSMixin to MSSBase, now derived from abc.ABCMeta
       - tools: force write of file when saving a PNG file
       - tests: fix tests on macOS with Retina display
-      - Windows: fix multi-thread unsafe and update test
+      - Windows: fixed multi-thread safety (fixes #150)
+      - :heart: contributors: @narumishi
 
 5.0.0   2019/12/31
       - removed support for Python 2.7

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,7 @@ History:
       - MSS: renamed again MSSMixin to MSSBase, now derived from abc.ABCMeta
       - tools: force write of file when saving a PNG file
       - tests: fix tests on macOS with Retina display
+      - Windows: fix multi-thread unsafe and update test
 
 5.0.0   2019/12/31
       - removed support for Python 2.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,6 @@ base.py
 windows.py
 ----------
  - Replaced ``MSS.srcdc`` with ``MSS.srcdc_dict``
- - add a threading lock ``MSS._lock``
 
 
 5.0.0 (2019-12-31)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ base.py
 
 windows.py
 ----------
- - replace ``MSS.srcdc`` with ``MSS.srcdc_dict``
+ - Replaced ``MSS.srcdc`` with ``MSS.srcdc_dict``
  - add a threading lock ``MSS._lock``
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ base.py
 - ``MSSBase.monitor`` is now an abstract property
 - ``MSSBase.grab()`` is now an abstract method
 
+windows.py
+----------
+ - replace ``MSS.srcdc`` with ``MSS.srcdc_dict``
+ - add a threading lock ``MSS._lock``
+
 
 5.0.0 (2019-12-31)
 ==================

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -30,6 +30,9 @@ Jochen 'cycomanic' Schroeder [https://github.com/cycomanic]
 Karan Lyons <karan@karanlyons.com> [https://karanlyons.com] [https://github.com/karanlyons]
     - MacOS: Proper support for display scaling
 
+narumi [https://github.com/narumishi]
+    - Windows: fix multi-thread unsafe
+
 Oros <oros@ecirtam.net> [https://ecirtam.net]
     - GNU/Linux tester
 

--- a/mss/tests/test_windows.py
+++ b/mss/tests/test_windows.py
@@ -59,8 +59,10 @@ def run_child_thread(loops):
 
 
 def test_thread_safety():
-    """Thread safety test for issue #150."""
-    # let thread 1 finished ahead of thread2
+    """Thread safety test for issue #150.
+    The following code will throw a ScreenShotError exception if thread-safety is not guaranted.
+    """
+    # Let thread 1 finished ahead of thread 2
     thread1 = threading.Thread(target=run_child_thread, args=(30,))
     thread2 = threading.Thread(target=run_child_thread, args=(50,))
     thread1.start()

--- a/mss/tests/test_windows.py
+++ b/mss/tests/test_windows.py
@@ -52,11 +52,10 @@ def test_region_caching():
 
 
 def run_child_thread(loops):
-    # every loop will take about 1 second.
-    for i in range(loops):
+    """Every loop will take about 1 second."""
+    for _ in range(loops):
         with mss.mss() as sct:
-            mon = sct.monitors[1]
-            sct.grab(mon)
+            sct.grab(sct.monitors[1])
 
 
 def test_thread_safety():

--- a/mss/tests/test_windows.py
+++ b/mss/tests/test_windows.py
@@ -4,6 +4,7 @@ Source: https://github.com/BoboTiG/python-mss
 """
 
 import platform
+import threading
 
 import mss
 import pytest
@@ -48,3 +49,22 @@ def test_region_caching():
         # Grab the area 2 again, the cached BMP is used
         sct.grab(region2)
         assert bmp2 is MSS.bmp
+
+
+def run_child_thread(loops):
+    # every loop will take about 1 second.
+    for i in range(loops):
+        with mss.mss() as sct:
+            mon = sct.monitors[1]
+            sct.grab(mon)
+
+
+def test_thread_safety():
+    """Thread safety test for issue #150."""
+    # let thread 1 finished ahead of thread2
+    thread1 = threading.Thread(target=run_child_thread, args=(30,))
+    thread2 = threading.Thread(target=run_child_thread, args=(50,))
+    thread1.start()
+    thread2.start()
+    thread1.join()
+    thread2.join()

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -5,6 +5,7 @@ Source: https://github.com/BoboTiG/python-mss
 
 import sys
 import ctypes
+import threading
 from ctypes.wintypes import (
     BOOL,
     DOUBLE,
@@ -70,10 +71,13 @@ class MSS(MSSBase):
 
     __slots__ = {"_bbox", "_bmi", "_data", "gdi32", "monitorenumproc", "user32"}
 
-    # Class attributes instancied one time to prevent resource leaks.
+    # Class attributes instanced one time to prevent resource leaks.
     bmp = None
     memdc = None
-    srcdc = None
+    # a dict to maintain srcdc values created by multiple threads.
+    srcdc_dict = {}
+    # a threading lock to lock resources(bmp/memdc/srcdc) inside grab method.
+    _lock = threading.Lock()
 
     def __init__(self, **_):
         # type: (Any) -> None
@@ -93,9 +97,9 @@ class MSS(MSSBase):
         self._bbox = {"height": 0, "width": 0}
         self._data = ctypes.create_string_buffer(0)  # type: ctypes.Array[ctypes.c_char]
 
-        if not MSS.srcdc or not MSS.memdc:
-            MSS.srcdc = self.user32.GetWindowDC(0)
-            MSS.memdc = self.gdi32.CreateCompatibleDC(MSS.srcdc)
+        srcdc = self._get_srcdc()
+        if not MSS.memdc:
+            MSS.memdc = self.gdi32.CreateCompatibleDC(srcdc)
 
         bmi = BITMAPINFO()
         bmi.bmiHeader.biSize = ctypes.sizeof(BITMAPINFOHEADER)
@@ -174,6 +178,17 @@ class MSS(MSSBase):
             # Windows Vista, 7, 8 and Server 2012
             self.user32.SetProcessDPIAware()
 
+    def _get_srcdc(self):
+        # Fix thread unsafe issue:
+        # In multithreading, if the thread who creates srcdc is died, srcdc is no longer valid to grab screen.
+        # The srcdc attribute is replaced with srcdc_dict to maintain the srcdc values in multithreading
+        # Since current thread and main thread is always alive, reuse their srcdc value first.
+        cur_thread, main_thread = threading.current_thread(), threading.main_thread()
+        srcdc = MSS.srcdc_dict.get(cur_thread) or MSS.srcdc_dict.get(main_thread)
+        if not srcdc:
+            srcdc = MSS.srcdc_dict[cur_thread] = self.user32.GetWindowDC(0)
+        return srcdc
+
     @property
     def monitors(self):
         # type: () -> Monitors
@@ -251,6 +266,9 @@ class MSS(MSSBase):
             Thanks to http://stackoverflow.com/a/3688682
         """
 
+        # Acquire lock to prevent resources from being modified by multiple threads at same time.
+        MSS._lock.acquire()
+
         # Convert PIL bbox style
         if isinstance(monitor, tuple):
             monitor = {
@@ -260,7 +278,7 @@ class MSS(MSSBase):
                 "height": monitor[3] - monitor[1],
             }
 
-        srcdc, memdc = MSS.srcdc, MSS.memdc
+        srcdc, memdc = self._get_srcdc(), MSS.memdc
         width, height = monitor["width"], monitor["height"]
 
         if (self._bbox["height"], self._bbox["width"]) != (height, width):
@@ -287,6 +305,7 @@ class MSS(MSSBase):
         bits = self.gdi32.GetDIBits(
             memdc, MSS.bmp, 0, height, self._data, self._bmi, DIB_RGB_COLORS
         )
+        MSS._lock.release()
         if bits != height:
             raise ScreenShotError("gdi32.GetDIBits() failed.")
 

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -74,9 +74,11 @@ class MSS(MSSBase):
     # Class attributes instanced one time to prevent resource leaks.
     bmp = None
     memdc = None
-    # a dict to maintain srcdc values created by multiple threads.
+
+    # A dict to maintain *srcdc* values created by multiple threads.
     srcdc_dict = {}
-    # a threading lock to lock resources(bmp/memdc/srcdc) inside grab method.
+
+    # A threading lock to lock resources(bmp/memdc/srcdc) inside .grab() method.
     _lock = threading.Lock()
 
     def __init__(self, **_):

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -181,10 +181,13 @@ class MSS(MSSBase):
             self.user32.SetProcessDPIAware()
 
     def _get_srcdc(self):
-        # Fix thread unsafe issue:
-        # In multithreading, if the thread who creates srcdc is died, srcdc is no longer valid to grab screen.
-        # The srcdc attribute is replaced with srcdc_dict to maintain the srcdc values in multithreading
-        # Since current thread and main thread is always alive, reuse their srcdc value first.
+        """
+        Retrieve a thread-safe HDC from GetWindowDC().
+        In multithreading, if the thread who creates *srcdc* is dead, *srcdc* will
+        no longer be valid to grab the screen. The *srcdc* attribute is replaced
+        with *srcdc_dict* to maintain the *srcdc* values in multithreading.
+        Since the current thread and main thread are always alive, reuse their *srcdc* value first.
+        """
         cur_thread, main_thread = threading.current_thread(), threading.main_thread()
         srcdc = MSS.srcdc_dict.get(cur_thread) or MSS.srcdc_dict.get(main_thread)
         if not srcdc:


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes #150 
- replace `srcdc` with `srcdc_dict` to maintain srcdc values created by multiple threads
- add a threading lock `MSS._lock` to ensure multi-thread safe

It is **very** important to keep up to date tests and documentation.

- [x] Tests added/updated
- [x] Documentation updated

Is your code right?

- [ ] PEP8 compliant
- [x] `flake8` passed
