### PR TITLE
Adjustments following previous commit

### DIFF
--- a/mss/tests/test_windows.py
+++ b/mss/tests/test_windows.py
@@ -27,10 +27,6 @@ def test_region_caching():
     """The region to grab is cached, ensure this is well-done."""
     from mss.windows import MSS
 
-    # Same sizes but different positions
-    region1 = {"top": 0, "left": 0, "width": 200, "height": 200}
-    region2 = {"top": 200, "left": 200, "width": 200, "height": 200}
-
     with mss.mss() as sct:
         # Reset the current BMP
         if MSS.bmp:
@@ -38,21 +34,23 @@ def test_region_caching():
             MSS.bmp = None
 
         # Grab the area 1
+        region1 = {"top": 0, "left": 0, "width": 200, "height": 200}
         sct.grab(region1)
-        bmp1 = MSS.bmp
+        bmp1 = id(MSS.bmp)
 
         # Grab the area 2, the cached BMP is used
+        # Same sizes but different positions
+        region2 = {"top": 200, "left": 200, "width": 200, "height": 200}
         sct.grab(region2)
-        bmp2 = MSS.bmp
-        assert bmp1 is bmp2
+        bmp2 = id(MSS.bmp)
+        assert bmp1 == bmp2
 
         # Grab the area 2 again, the cached BMP is used
         sct.grab(region2)
-        assert bmp2 is MSS.bmp
+        assert bmp2 == id(MSS.bmp)
 
 
 def run_child_thread(loops):
-    """Every loop will take about 1 second."""
     for _ in range(loops):
         with mss.mss() as sct:
             sct.grab(sct.monitors[1])

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -27,7 +27,7 @@ from .base import MSSBase
 from .exception import ScreenShotError
 
 if TYPE_CHECKING:
-    from typing import Any  # noqa
+    from typing import Any, Dict  # noqa
 
     from .models import Monitor, Monitors  # noqa
     from .screenshot import ScreenShot  # noqa
@@ -76,7 +76,7 @@ class MSS(MSSBase):
     memdc = None
 
     # A dict to maintain *srcdc* values created by multiple threads.
-    srcdc_dict = {}
+    srcdc_dict = {}  # type: Dict[int, Any]
 
     # A threading lock to lock resources(bmp/memdc/srcdc) inside .grab() method.
     _lock = threading.Lock()

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,5 @@ addopts =
     --showlocals
     --strict
     --failed-first
-    --no-print-logs
     -r fE
     -v


### PR DESCRIPTION
- Fixed the type annotation of `srcdc_dict`.
- Removed obsolete comment in `test_windows.py`.
- Fixed `PytestDeprecationWarning: --no-print-logs is deprecated and scheduled for removal in pytest 6.0.`
- Fixed Sourcery issues in `test_windows.py`.
