### PR TITLE
Fix usage of deprecated "license_file" option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,7 @@ History:
 <see Git checking messages for history>
 
 5.1.1   2020/xx/xx
-      -
+      - removed usage of deprecated "license_file" option for "license_files"
       - :heart: contributors: @
 
 5.1.0   2020/04/30

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,8 @@ project_urls =
     Tracker = https://github.com/BoboTiG/python-mss/issues
 keywords = screen, screenshot, screencapture, screengrab
 license = MIT
-license_file = LICENSE
+license_files =
+    LICENSE
 platforms = Darwin, Linux, Windows
 classifiers =
     Development Status :: 5 - Production/Stable


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes that warning:
```
DeprecationWarning: The "license_file" option is deprecated. Use "license_files" instead.
```