### PR TITLE
The module is now available on conda (closes #170)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ History:
 6.0.0   2020/xx/xx
       - removed usage of deprecated "license_file" option for "license_files"
       - fixed flake8 usage in pre-commit
+      - the module is now available on conda (closes #170)
       - MSS: the implementation is now thread-safe on all OSes (fixes #169)
       - tests: fixed a random bug on test_grab_with_tuple_percents() (fixes #142)
       - :heart: contributors: @

--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,8 @@ Python MSS
     :target: https://saythanks.io/to/BoboTiG
 .. image:: https://pepy.tech/badge/mss
     :target: https://pepy.tech/project/mss
+.. image:: https://anaconda.org/conda-forge/python-mss/badges/installer/conda.svg
+    :target: https://anaconda.org/conda-forge/python-mss
 
 
 .. code-block:: python
@@ -41,3 +43,7 @@ Installation
 You can install it with pip::
 
     python -m pip install -U --user mss
+
+Or you can install it with conda::
+
+    conda install -c conda-forge python-mss

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,6 +11,12 @@ Quite simple::
 
     $ python -m pip install -U --user mss
 
+Conda Package
+-------------
+
+The module is also available from conda::
+
+    $ conda install -c conda-forge python-mss
 
 From Sources
 ============


### PR DESCRIPTION
Links:
- https://anaconda.org/conda-forge/python-mss
- https://github.com/conda-forge/python-mss-feedstock

### Changes proposed in this PR

- Fixes #170