### PR TITLE
Linux: Mouse support

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,6 +12,9 @@ Alexander 'thehesiod' Mohr [https://github.com/thehesiod]
 Andreas Buhr [https://www.andreasbuhr.de]
     - Bugfix for multi-monitor detection
 
+Boutallaka 'zorvios' Yassir [https://github.com/zorvios]
+    - GNU/Linux: Mouse support
+
 bubulle [http://indexerror.net/user/bubulle]
     - Windows: efficiency of MSS.get_pixels()
 

--- a/mss/darwin.py
+++ b/mss/darwin.py
@@ -218,3 +218,9 @@ class MSS(MSSBase):
                 core.CFRelease(copy_data)
 
         return self.cls_image(data, monitor, size=Size(width, height))
+
+    def _cursor_impl(self):
+        # type: () -> ScreenShot
+        """ Retrieve all cursor data. Pixels have to be RGB. """
+
+        raise NotImplementedError

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -277,3 +277,9 @@ class MSS(MSSBase):
             raise ScreenShotError("gdi32.GetDIBits() failed.")
 
         return self.cls_image(bytearray(self._data), monitor)
+
+    def _cursor_impl(self):
+        # type: () -> ScreenShot
+        """ Retrieve all cursor data. Pixels have to be RGB. """
+
+        raise NotImplementedError


### PR DESCRIPTION
### Changes proposed in this PR

- Partial Fix for #55 
-- Linux cursor image
-- merge the cursor into the pixels directly and not only in the final PNG
-- Added keyword  with_cursor=False

It is **very** important to keep up to date tests and documentation.

- [ ] Tests added/updated
- [ ] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
