### PR TITLE
setup: fix three setuptools warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,11 +2,11 @@
 name = mss
 version = 6.1.0
 author = Mickaël 'Tiger-222' Schoentgen
-author-email = contact@tiger-222.fr
+author_email = contact@tiger-222.fr
 description = An ultra fast cross-platform multiple screenshots module in pure python using ctypes.
 long_description = file: README.rst
 url = https://github.com/BoboTiG/python-mss
-home-page = https://pypi.org/project/mss/
+home_page = https://pypi.org/project/mss/
 project_urls =
     Documentation = https://python-mss.readthedocs.io
     Source = https://github.com/BoboTiG/python-mss
@@ -31,7 +31,7 @@ classifiers =
     Topic :: Software Development :: Libraries
 
 [options]
-zip-safe = False
+zip_safe = False
 include_package_data = True
 packages = mss
 python_requires = >=3.5


### PR DESCRIPTION
UserWarning: Usage of dash-separated 'author-email' will not be supported in future versions. Please use the underscore name 'author_email' instead
UserWarning: Usage of dash-separated 'home-page' will not be supported in future versions. Please use the underscore name 'home_page' instead
UserWarning: Usage of dash-separated 'zip-safe' will not be supported in future versions. Please use the underscore name 'zip_safe' instead