### PR TITLE
Linux: removed get_error_details(), use the ScreenShotError details a…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    paths:
-      - ".github/workflows/tests.yml"
-      - "setup.cfg"
-      - "mss/**"
 
 jobs:
   quality:
@@ -87,7 +83,7 @@ jobs:
         if: matrix.os.emoji == '🐧'
         run: |
           export DISPLAY=:99
-          sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
+          sudo Xvfb -ac ${DISPLAY} -screen 0 1280x1024x24 > /dev/null 2>&1 &
           python -m pytest
       - name: Tests on other platforms
         if: matrix.os.emoji != '🐧'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@ History:
 
 <see Git checking messages for history>
 
-7.0.2   2023/0x/xx
+8.0.0   2023/0x/xx
+      - Linux: removed get_error_details(), use the ScreenShotError details attribute instead
       - dev: removed pre-commit
       - tests: removed tox
       - tests: added PyPy 3.9

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -19,14 +19,6 @@ GNU/Linux
 
 .. attribute:: CFUNCTIONS
 
-.. attribute:: ERROR
-
-    :type: types.SimpleNamspacedict
-
-    The `details` attribute contains the latest Xlib or XRANDR function. It is a dict.
-
-    .. versionadded:: 5.0.0
-
 .. attribute:: PLAINMASK
 
 .. attribute:: ZPIXMAP
@@ -39,33 +31,6 @@ GNU/Linux
         :param display: The display to use.
 
         GNU/Linux initializations.
-
-    .. method:: get_error_details()
-
-        :rtype: Optional[dict[str, Any]]
-
-        Get more information about the latest X server error. To use in such scenario::
-
-            with mss.mss() as sct:
-                # Take a screenshot of a region out of monitor bounds
-                rect = {"left": -30, "top": 0, "width": 100, "height": 100}
-
-                try:
-                    sct.grab(rect)
-                except ScreenShotError:
-                    details = sct.get_error_details()
-                    """
-                    >>> import pprint
-                    >>> pprint.pprint(details)
-                    {'xerror': 'BadFont (invalid Font parameter)',
-                     'xerror_details': {'error_code': 7,
-                                        'minor_code': 0,
-                                        'request_code': 0,
-                                        'serial': 422,
-                                        'type': 0}}
-                    """
-
-        .. versionadded:: 4.0.0
 
     .. method:: grab(monitor)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -27,7 +27,7 @@ author = "Tiger-222"
 # built documents.
 #
 # The short X.Y version.
-version = "7.0.1"
+version = "8.0.0"
 
 # The full version, including alpha/beta/rc tags.
 release = "latest"

--- a/mss/__init__.py
+++ b/mss/__init__.py
@@ -11,7 +11,7 @@ If that URL should fail, try contacting the author.
 from .exception import ScreenShotError
 from .factory import mss
 
-__version__ = "7.0.1"
+__version__ = "8.0.0"
 __author__ = "Mickaël 'Tiger-222' Schoentgen"
 __copyright__ = """
 Copyright (c) 2013-2023, Mickaël 'Tiger-222' Schoentgen

--- a/mss/linux.py
+++ b/mss/linux.py
@@ -22,7 +22,6 @@ from ctypes import (
     c_ushort,
     c_void_p,
 )
-from types import SimpleNamespace
 from typing import Any, Dict, Optional, Tuple, Union
 
 from .base import MSSBase, lock
@@ -33,7 +32,6 @@ from .screenshot import ScreenShot
 __all__ = ("MSS",)
 
 
-ERROR = SimpleNamespace(details=None)
 PLAINMASK = 0x00FFFFFF
 ZPIXMAP = 2
 
@@ -158,29 +156,46 @@ class XRRCrtcInfo(Structure):
     ]
 
 
+_ERROR = {}
+
+
 @CFUNCTYPE(c_int, POINTER(Display), POINTER(Event))
-def error_handler(_: Any, event: Any) -> int:
+def error_handler(display: Display, event: Event) -> int:
     """Specifies the program's supplied error handler."""
+    x11 = ctypes.util.find_library("X11")
+    if not x11:
+        return 0
+
+    # Get the specific error message
+    xlib = ctypes.cdll.LoadLibrary(x11)
+    get_error = getattr(xlib, "XGetErrorText")
+    get_error.argtypes = [POINTER(Display), c_int, c_char_p, c_int]
+    get_error.restype = c_void_p
+
     evt = event.contents
-    ERROR.details = {
-        "type": evt.type,
-        "serial": evt.serial,
+    error = ctypes.create_string_buffer(1024)
+    get_error(display, evt.error_code, error, len(error))
+
+    _ERROR[threading.current_thread()] = {
+        "error": error.value.decode("utf-8"),
         "error_code": evt.error_code,
-        "request_code": evt.request_code,
         "minor_code": evt.minor_code,
+        "request_code": evt.request_code,
+        "serial": evt.serial,
+        "type": evt.type,
     }
+
     return 0
 
 
-def validate(
-    retval: int, func: Any, args: Tuple[Any, Any]
-) -> Optional[Tuple[Any, Any]]:
+def validate(retval: int, func: Any, args: Tuple[Any, Any]) -> Tuple[Any, Any]:
     """Validate the returned value of a Xlib or XRANDR function."""
 
-    if retval != 0 and not ERROR.details:
+    current_thread = threading.current_thread()
+    if retval != 0 and current_thread not in _ERROR:
         return args
 
-    details = {"retval": retval, "args": args}
+    details = _ERROR.pop(current_thread, {})
     raise ScreenShotError(f"{func.__name__}() failed", details=details)
 
 
@@ -196,7 +211,6 @@ def validate(
 CFUNCTIONS: CFunctions = {
     "XDefaultRootWindow": ("xlib", [POINTER(Display)], POINTER(XWindowAttributes)),
     "XDestroyImage": ("xlib", [POINTER(XImage)], c_void_p),
-    "XGetErrorText": ("xlib", [POINTER(Display), c_int, c_char_p, c_int], c_void_p),
     "XGetImage": (
         "xlib",
         [
@@ -331,15 +345,13 @@ class MSS(MSSBase):
         Since the current thread and main thread are always alive, reuse their
         *display* value first.
         """
-        cur_thread, main_thread = threading.current_thread(), threading.main_thread()
-        current_display = MSS._display_dict.get(cur_thread) or MSS._display_dict.get(
-            main_thread
-        )
+        current_thread = threading.current_thread()
+        current_display = MSS._display_dict.get(current_thread)
         if current_display:
             display = current_display
         else:
             display = self.xlib.XOpenDisplay(disp)
-            MSS._display_dict[cur_thread] = display
+            MSS._display_dict[current_thread] = display
         return display
 
     def _set_cfunctions(self) -> None:
@@ -359,27 +371,6 @@ class MSS(MSSBase):
                     argtypes=argtypes,
                     restype=restype,
                 )
-
-    def get_error_details(self) -> Optional[Dict[str, Any]]:
-        """Get more information about the latest X server error."""
-
-        details: Dict[str, Any] = {}
-
-        if ERROR.details:
-            details = {"xerror_details": ERROR.details}
-            ERROR.details = None
-            xserver_error = ctypes.create_string_buffer(1024)
-            self.xlib.XGetErrorText(
-                self._get_display(),
-                details.get("xerror_details", {}).get("error_code", 0),
-                xserver_error,
-                len(xserver_error),
-            )
-            xerror = xserver_error.value.decode("utf-8")
-            if xerror != "0":
-                details["xerror"] = xerror
-
-        return details
 
     def _monitors_impl(self) -> None:
         """Get positions of monitors. It will populate self._monitors."""

--- a/mss/tests/test_gnu_linux.py
+++ b/mss/tests/test_gnu_linux.py
@@ -9,6 +9,7 @@ import platform
 import pytest
 
 import mss
+import mss.linux
 from mss.base import MSSBase
 from mss.exception import ScreenShotError
 
@@ -107,18 +108,23 @@ def test_no_xrandr_extension(monkeypatch):
 
 def test_region_out_of_monitor_bounds():
     display = os.getenv("DISPLAY")
+    monitor = {"left": -30, "top": 0, "width": 100, "height": 100}
+
+    assert not mss.linux._ERROR
+
     with mss.mss(display=display) as sct:
         with pytest.raises(ScreenShotError) as exc:
-            monitor = {"left": -30, "top": 0, "width": 100, "height": 100}
-            assert sct.grab(monitor)
+            sct.grab(monitor)
 
         assert str(exc.value)
-        assert "retval" in exc.value.details
-        assert "args" in exc.value.details
 
-        details = sct.get_error_details()
-        assert details["xerror"]
-        assert isinstance(details["xerror_details"], dict)
+        details = exc.value.details
+        assert details
+        assert isinstance(details, dict)
+        assert isinstance(details["error"], str)
+        assert not mss.linux._ERROR
+
+    assert not mss.linux._ERROR
 
 
 def test_has_extension():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mss
-version = 7.0.1
+version = 8.0.0
 author = Mickaël 'Tiger-222' Schoentgen
 author_email = contact@tiger-222.fr
 description = An ultra fast cross-platform multiple screenshots module in pure python using ctypes.
@@ -20,6 +20,8 @@ platforms = Darwin, Linux, Windows
 classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: MIT License
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only


### PR DESCRIPTION
…ttribute instead

It should fix threading issues, and prevent old errors messing with new X11 calls.

### Changes proposed in this PR

- Related to #220

It is **very** important to keep up to date tests and documentation.

- [x] Tests added/updated
- [x] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
