### PR TITLE
fix(Linux): reset X server error handler on exit to prevent issues with Tk/Tkinter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,8 +56,6 @@ jobs:
           - emoji: 🪟
             runs-on: [windows-latest]
         python:
-          - name: CPython 3.7
-            runs-on: "3.7"
           - name: CPython 3.8
             runs-on: "3.8"
           - name: CPython 3.9

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,8 @@ History:
 <see Git checking messages for history>
 
 8.0.0   2023/0x/xx
+      - the whole source code was migrated to PEP 570 (Python Positional-Only Parameters)
+      - removed support for Python 3.7
       - Linux: added mouse support (#232)
       - Linux: refactored how internal handles are stored to fix issues with multiple X servers, and TKinter.
                No more side effects, and when leaving the context manager, resources are all freed (#224, #234)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ History:
 8.0.0   2023/0x/xx
       - the whole source code was migrated to PEP 570 (Python Positional-Only Parameters)
       - removed support for Python 3.7
+      - Linux: reset X server error handler on exit to prevent issues with Tk/Tkinter (#235)
       - Linux: added mouse support (#232)
       - Linux: refactored how internal handles are stored to fix issues with multiple X servers, and TKinter.
                No more side effects, and when leaving the context manager, resources are all freed (#224, #234)

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Python MSS
 
 An ultra fast cross-platform multiple screenshots module in pure python using ctypes.
 
-- **Python 3.7+** and PEP8 compliant, no dependency, thread-safe;
+- **Python 3.8+** and PEP8 compliant, no dependency, thread-safe;
 - very basic, it will grab one screen shot by monitor or a screen shot of all monitors and save it to a PNG file;
 - but you can use PIL and benefit from all its formats (or add yours directly);
 - integrate well with Numpy and OpenCV;

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -43,19 +43,33 @@ GNU/Linux
 
 .. class:: Display
 
+    Structure that serves as the connection to the X server, and that contains all the information about that X server.
+
 .. class:: Event
+
+    XErrorEvent to debug eventual errors.
 
 .. class:: XFixesCursorImage
 
-.. class:: XWindowAttributes
+    Cursor structure
 
 .. class:: XImage
+
+    Description of an image as it exists in the client's memory.
+
+.. class:: XRRCrtcInfo
+
+    Structure that contains CRTC information.
 
 .. class:: XRRModeInfo
 
 .. class:: XRRScreenResources
 
-.. class:: XRRCrtcInfo
+    Structure that contains arrays of XIDs that point to the available outputs and associated CRTCs.
+
+.. class:: XWindowAttributes
+
+    Attributes for the specified window.
 
 .. class:: MSS
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Welcome to Python MSS's documentation!
 
 An ultra fast cross-platform multiple screenshots module in pure python using ctypes.
 
-    - **Python 3.7+** and :pep:`8` compliant, no dependency, thread-safe;
+    - **Python 3.8+** and :pep:`8` compliant, no dependency, thread-safe;
     - very basic, it will grab one screen shot by monitor or a screen shot of all monitors and save it to a PNG file;
     - but you can use PIL and benefit from all its formats (or add yours directly);
     - integrate well with Numpy and OpenCV;

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -5,7 +5,7 @@ Support
 Feel free to try MSS on a system we had not tested, and let us know by creating an `issue <https://github.com/BoboTiG/python-mss/issues>`_.
 
     - OS: GNU/Linux, macOS and Windows
-    - Python: 3.7 and newer
+    - Python: 3.8 and newer
 
 
 Future
@@ -32,4 +32,5 @@ Abandoned
 - Python 3.3 (2017-12-05)
 - Python 3.4 (2018-03-19)
 - Python 3.5 (2022-10-27)
-- Python 3.6 (202x-xx-xx)
+- Python 3.6 (2022-10-27)
+- Python 3.7 (2023-xx-xx)

--- a/mss/__main__.py
+++ b/mss/__main__.py
@@ -4,7 +4,7 @@ Source: https://github.com/BoboTiG/python-mss
 """
 import os.path
 from argparse import ArgumentParser
-from typing import List, Optional
+from typing import List
 
 from . import __version__
 from .exception import ScreenShotError
@@ -12,7 +12,7 @@ from .factory import mss
 from .tools import to_png
 
 
-def main(args: Optional[List[str]] = None) -> int:
+def main(args: List[str], /) -> int:
     """Main logic."""
 
     cli_args = ArgumentParser()

--- a/mss/base.py
+++ b/mss/base.py
@@ -22,6 +22,8 @@ class MSSBase(metaclass=ABCMeta):
 
     def __init__(
         self,
+        /,
+        *,
         compression_level: int = 6,
         display: Optional[Union[bytes, str]] = None,  # Linux only
         max_displays: int = 32,  # Mac only
@@ -48,7 +50,7 @@ class MSSBase(metaclass=ABCMeta):
         """Retrieve all cursor data. Pixels have to be RGB."""
 
     @abstractmethod
-    def _grab_impl(self, monitor: Monitor) -> ScreenShot:
+    def _grab_impl(self, monitor: Monitor, /) -> ScreenShot:
         """
         Retrieve all pixels from a monitor. Pixels have to be RGB.
         That method has to be run using a threading lock.
@@ -64,7 +66,7 @@ class MSSBase(metaclass=ABCMeta):
     def close(self) -> None:
         """Clean-up."""
 
-    def grab(self, monitor: Union[Monitor, Tuple[int, int, int, int]]) -> ScreenShot:
+    def grab(self, monitor: Union[Monitor, Tuple[int, int, int, int]], /) -> ScreenShot:
         """
         Retrieve screen pixels for a given monitor.
 
@@ -120,6 +122,8 @@ class MSSBase(metaclass=ABCMeta):
 
     def save(
         self,
+        /,
+        *,
         mon: int = 0,
         output: str = "monitor-{mon}.png",
         callback: Optional[Callable[[str], None]] = None,
@@ -170,9 +174,8 @@ class MSSBase(metaclass=ABCMeta):
             mon = 0 if mon == -1 else mon
             try:
                 monitor = monitors[mon]
-            except IndexError:
-                # pylint: disable=raise-missing-from
-                raise ScreenShotError(f"Monitor {mon!r} does not exist.")
+            except IndexError as exc:
+                raise ScreenShotError(f"Monitor {mon!r} does not exist.") from exc
 
             output = output.format(mon=mon, date=datetime.now(), **monitor)
             if callable(callback):
@@ -181,7 +184,7 @@ class MSSBase(metaclass=ABCMeta):
             to_png(sct.rgb, sct.size, level=self.compression_level, output=output)
             yield output
 
-    def shot(self, **kwargs: Any) -> str:
+    def shot(self, /, **kwargs: Any) -> str:
         """
         Helper to save the screen shot of the 1st monitor, by default.
         You can pass the same arguments as for ``save``.
@@ -191,7 +194,7 @@ class MSSBase(metaclass=ABCMeta):
         return next(self.save(**kwargs))
 
     @staticmethod
-    def _merge(screenshot: ScreenShot, cursor: ScreenShot) -> ScreenShot:
+    def _merge(screenshot: ScreenShot, cursor: ScreenShot, /) -> ScreenShot:
         """Create composite image by blending screenshot and mouse cursor."""
 
         # pylint: disable=too-many-locals,invalid-name
@@ -244,6 +247,7 @@ class MSSBase(metaclass=ABCMeta):
         func: str,
         argtypes: List[Any],
         restype: Any,
+        /,
         errcheck: Optional[Callable] = None,
     ) -> None:
         """Factory to create a ctypes function and automatically manage errors."""

--- a/mss/darwin.py
+++ b/mss/darwin.py
@@ -66,11 +66,7 @@ CFUNCTIONS: CFunctions = {
     "CFDataGetLength": ("core", [c_void_p], c_uint64),
     "CFRelease": ("core", [c_void_p], c_void_p),
     "CGDataProviderRelease": ("core", [c_void_p], c_void_p),
-    "CGGetActiveDisplayList": (
-        "core",
-        [c_uint32, POINTER(c_uint32), POINTER(c_uint32)],
-        c_int32,
-    ),
+    "CGGetActiveDisplayList": ("core", [c_uint32, POINTER(c_uint32), POINTER(c_uint32)], c_int32),
     "CGImageGetBitsPerPixel": ("core", [c_void_p], int),
     "CGImageGetBytesPerRow": ("core", [c_void_p], int),
     "CGImageGetDataProvider": ("core", [c_void_p], c_void_p),
@@ -78,11 +74,7 @@ CFUNCTIONS: CFunctions = {
     "CGImageGetWidth": ("core", [c_void_p], int),
     "CGRectStandardize": ("core", [CGRect], CGRect),
     "CGRectUnion": ("core", [CGRect, CGRect], CGRect),
-    "CGWindowListCreateImage": (
-        "core",
-        [CGRect, c_uint32, c_uint32, c_uint32],
-        c_void_p,
-    ),
+    "CGWindowListCreateImage": ("core", [CGRect, c_uint32, c_uint32, c_uint32], c_void_p),
 }
 
 
@@ -94,7 +86,7 @@ class MSS(MSSBase):
 
     __slots__ = {"core", "max_displays"}
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, /, **kwargs: Any) -> None:
         """macOS initialisations."""
 
         super().__init__(**kwargs)
@@ -124,12 +116,7 @@ class MSS(MSSBase):
         cfactory = self._cfactory
         attrs = {"core": self.core}
         for func, (attr, argtypes, restype) in CFUNCTIONS.items():
-            cfactory(
-                attr=attrs[attr],
-                func=func,
-                argtypes=argtypes,
-                restype=restype,
-            )
+            cfactory(attrs[attr], func, argtypes, restype)
 
     def _monitors_impl(self) -> None:
         """Get positions of monitors. It will populate self._monitors."""
@@ -176,7 +163,7 @@ class MSS(MSSBase):
             "height": int_(all_monitors.size.height),
         }
 
-    def _grab_impl(self, monitor: Monitor) -> ScreenShot:
+    def _grab_impl(self, monitor: Monitor, /) -> ScreenShot:
         """Retrieve all pixels from a monitor. Pixels have to be RGB."""
 
         # pylint: disable=too-many-locals

--- a/mss/exception.py
+++ b/mss/exception.py
@@ -8,6 +8,6 @@ from typing import Any, Dict, Optional
 class ScreenShotError(Exception):
     """Error handling class."""
 
-    def __init__(self, message: str, details: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, message: str, /, *, details: Optional[Dict[str, Any]] = None) -> None:
         super().__init__(message)
         self.details = details or {}

--- a/mss/linux.py
+++ b/mss/linux.py
@@ -66,8 +66,9 @@ class Event(Structure):
 
 class XFixesCursorImage(Structure):
     """
-    XFixes is an X Window System extension.
-    See /usr/include/X11/extensions/Xfixes.h
+    Cursor structure.
+    /usr/include/X11/extensions/Xfixes.h
+    https://github.com/freedesktop/xorg-libXfixes/blob/libXfixes-6.0.0/include/X11/extensions/Xfixes.h#L96
     """
 
     _fields_ = [
@@ -81,6 +82,72 @@ class XFixesCursorImage(Structure):
         ("pixels", POINTER(c_ulong)),
         ("atom", c_ulong),
         ("name", c_char_p),
+    ]
+
+
+class XImage(Structure):
+    """
+    Description of an image as it exists in the client's memory.
+    https://tronche.com/gui/x/xlib/graphics/images.html
+    """
+
+    _fields_ = [
+        ("width", c_int),
+        ("height", c_int),
+        ("xoffset", c_int),
+        ("format", c_int),
+        ("data", c_void_p),
+        ("byte_order", c_int),
+        ("bitmap_unit", c_int),
+        ("bitmap_bit_order", c_int),
+        ("bitmap_pad", c_int),
+        ("depth", c_int),
+        ("bytes_per_line", c_int),
+        ("bits_per_pixel", c_int),
+        ("red_mask", c_ulong),
+        ("green_mask", c_ulong),
+        ("blue_mask", c_ulong),
+    ]
+
+
+class XRRCrtcInfo(Structure):
+    """Structure that contains CRTC information."""
+
+    _fields_ = [
+        ("timestamp", c_ulong),
+        ("x", c_int),
+        ("y", c_int),
+        ("width", c_int),
+        ("height", c_int),
+        ("mode", c_long),
+        ("rotation", c_int),
+        ("noutput", c_int),
+        ("outputs", POINTER(c_long)),
+        ("rotations", c_ushort),
+        ("npossible", c_int),
+        ("possible", POINTER(c_long)),
+    ]
+
+
+class XRRModeInfo(Structure):
+    """Voilà, voilà."""
+
+
+class XRRScreenResources(Structure):
+    """
+    Structure that contains arrays of XIDs that point to the
+    available outputs and associated CRTCs.
+    """
+
+    _fields_ = [
+        ("timestamp", c_ulong),
+        ("configTimestamp", c_ulong),
+        ("ncrtc", c_int),
+        ("crtcs", POINTER(c_long)),
+        ("noutput", c_int),
+        ("outputs", POINTER(c_long)),
+        ("nmode", c_int),
+        ("modes", POINTER(XRRModeInfo)),
     ]
 
 
@@ -111,72 +178,6 @@ class XWindowAttributes(Structure):
         ("do_not_propagate_mask", c_ulong),
         ("override_redirect", c_int32),
         ("screen", c_ulong),
-    ]
-
-
-class XImage(Structure):
-    """
-    Description of an image as it exists in the client's memory.
-    https://tronche.com/gui/x/xlib/graphics/images.html
-    """
-
-    _fields_ = [
-        ("width", c_int),
-        ("height", c_int),
-        ("xoffset", c_int),
-        ("format", c_int),
-        ("data", c_void_p),
-        ("byte_order", c_int),
-        ("bitmap_unit", c_int),
-        ("bitmap_bit_order", c_int),
-        ("bitmap_pad", c_int),
-        ("depth", c_int),
-        ("bytes_per_line", c_int),
-        ("bits_per_pixel", c_int),
-        ("red_mask", c_ulong),
-        ("green_mask", c_ulong),
-        ("blue_mask", c_ulong),
-    ]
-
-
-class XRRModeInfo(Structure):
-    """Voilà, voilà."""
-
-
-class XRRScreenResources(Structure):
-    """
-    Structure that contains arrays of XIDs that point to the
-    available outputs and associated CRTCs.
-    """
-
-    _fields_ = [
-        ("timestamp", c_ulong),
-        ("configTimestamp", c_ulong),
-        ("ncrtc", c_int),
-        ("crtcs", POINTER(c_long)),
-        ("noutput", c_int),
-        ("outputs", POINTER(c_long)),
-        ("nmode", c_int),
-        ("modes", POINTER(XRRModeInfo)),
-    ]
-
-
-class XRRCrtcInfo(Structure):
-    """Structure that contains CRTC information."""
-
-    _fields_ = [
-        ("timestamp", c_ulong),
-        ("x", c_int),
-        ("y", c_int),
-        ("width", c_int),
-        ("height", c_int),
-        ("mode", c_long),
-        ("rotation", c_int),
-        ("noutput", c_int),
-        ("outputs", POINTER(c_long)),
-        ("rotations", c_ushort),
-        ("npossible", c_int),
-        ("possible", POINTER(c_long)),
     ]
 
 
@@ -226,7 +227,7 @@ def _validate(retval: int, func: Any, args: Tuple[Any, Any]) -> Tuple[Any, Any]:
 # This is a dict:
 #    cfunction: (attr, argtypes, restype)
 #
-# Available attr: xlib, xrandr.
+# Available attr: xfixes, xlib, xrandr.
 #
 # Note: keep it sorted by cfunction.
 CFUNCTIONS: CFunctions = {
@@ -292,7 +293,7 @@ class MSS(MSSBase):
     It uses intensively the Xlib and its Xrandr extension.
     """
 
-    __slots__ = {"xlib", "xrandr", "xfixes", "_handles"}
+    __slots__ = {"xfixes", "xlib", "xrandr", "_handles"}
 
     def __init__(self, **kwargs: Any) -> None:
         """GNU/Linux initialisations."""

--- a/mss/linux.py
+++ b/mss/linux.py
@@ -210,7 +210,7 @@ def _error_handler(display: Display, event: Event) -> int:
     return 0
 
 
-def _validate(retval: int, func: Any, args: Tuple[Any, Any]) -> Tuple[Any, Any]:
+def _validate(retval: int, func: Any, args: Tuple[Any, Any], /) -> Tuple[Any, Any]:
     """Validate the returned value of a Xlib or XRANDR function."""
 
     thread = current_thread()
@@ -237,52 +237,17 @@ CFUNCTIONS: CFunctions = {
     "XFixesGetCursorImage": ("xfixes", [POINTER(Display)], POINTER(XFixesCursorImage)),
     "XGetImage": (
         "xlib",
-        [
-            POINTER(Display),
-            POINTER(Display),
-            c_int,
-            c_int,
-            c_uint,
-            c_uint,
-            c_ulong,
-            c_int,
-        ],
+        [POINTER(Display), POINTER(Display), c_int, c_int, c_uint, c_uint, c_ulong, c_int],
         POINTER(XImage),
     ),
-    "XGetWindowAttributes": (
-        "xlib",
-        [POINTER(Display), POINTER(XWindowAttributes), POINTER(XWindowAttributes)],
-        c_int,
-    ),
+    "XGetWindowAttributes": ("xlib", [POINTER(Display), POINTER(XWindowAttributes), POINTER(XWindowAttributes)], c_int),
     "XOpenDisplay": ("xlib", [c_char_p], POINTER(Display)),
-    "XQueryExtension": (
-        "xlib",
-        [
-            POINTER(Display),
-            c_char_p,
-            POINTER(c_int),
-            POINTER(c_int),
-            POINTER(c_int),
-        ],
-        c_uint,
-    ),
+    "XQueryExtension": ("xlib", [POINTER(Display), c_char_p, POINTER(c_int), POINTER(c_int), POINTER(c_int)], c_uint),
     "XRRFreeCrtcInfo": ("xrandr", [POINTER(XRRCrtcInfo)], c_void_p),
     "XRRFreeScreenResources": ("xrandr", [POINTER(XRRScreenResources)], c_void_p),
-    "XRRGetCrtcInfo": (
-        "xrandr",
-        [POINTER(Display), POINTER(XRRScreenResources), c_long],
-        POINTER(XRRCrtcInfo),
-    ),
-    "XRRGetScreenResources": (
-        "xrandr",
-        [POINTER(Display), POINTER(Display)],
-        POINTER(XRRScreenResources),
-    ),
-    "XRRGetScreenResourcesCurrent": (
-        "xrandr",
-        [POINTER(Display), POINTER(Display)],
-        POINTER(XRRScreenResources),
-    ),
+    "XRRGetCrtcInfo": ("xrandr", [POINTER(Display), POINTER(XRRScreenResources), c_long], POINTER(XRRCrtcInfo)),
+    "XRRGetScreenResources": ("xrandr", [POINTER(Display), POINTER(Display)], POINTER(XRRScreenResources)),
+    "XRRGetScreenResourcesCurrent": ("xrandr", [POINTER(Display), POINTER(Display)], POINTER(XRRScreenResources)),
     "XSetErrorHandler": ("xlib", [c_void_p], c_int),
 }
 
@@ -295,7 +260,7 @@ class MSS(MSSBase):
 
     __slots__ = {"xfixes", "xlib", "xrandr", "_handles"}
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, /, **kwargs: Any) -> None:
         """GNU/Linux initialisations."""
 
         super().__init__(**kwargs)
@@ -355,7 +320,7 @@ class MSS(MSSBase):
 
         _ERROR.clear()
 
-    def _is_extension_enabled(self, name: str) -> bool:
+    def _is_extension_enabled(self, name: str, /) -> bool:
         """Return True if the given *extension* is enabled on the server."""
         with lock:
             major_opcode_return = c_int()
@@ -385,13 +350,7 @@ class MSS(MSSBase):
         }
         for func, (attr, argtypes, restype) in CFUNCTIONS.items():
             with suppress(AttributeError):
-                cfactory(
-                    attr=attrs[attr],
-                    errcheck=_validate,
-                    func=func,
-                    argtypes=argtypes,
-                    restype=restype,
-                )
+                cfactory(attrs[attr], func, argtypes, restype, errcheck=_validate)
 
     def _monitors_impl(self) -> None:
         """Get positions of monitors. It will populate self._monitors."""
@@ -435,7 +394,7 @@ class MSS(MSSBase):
             xrandr.XRRFreeCrtcInfo(crtc)
         xrandr.XRRFreeScreenResources(mon)
 
-    def _grab_impl(self, monitor: Monitor) -> ScreenShot:
+    def _grab_impl(self, monitor: Monitor, /) -> ScreenShot:
         """Retrieve all pixels from a monitor. Pixels have to be RGB."""
 
         ximage = self.xlib.XGetImage(

--- a/mss/screenshot.py
+++ b/mss/screenshot.py
@@ -21,7 +21,7 @@ class ScreenShot:
 
     __slots__ = {"__pixels", "__rgb", "pos", "raw", "size"}
 
-    def __init__(self, data: bytearray, monitor: Monitor, size: Optional[Size] = None) -> None:
+    def __init__(self, data: bytearray, monitor: Monitor, /, *, size: Optional[Size] = None) -> None:
         self.__pixels: Optional[Pixels] = None
         self.__rgb: Optional[bytes] = None
 
@@ -55,7 +55,7 @@ class ScreenShot:
         }
 
     @classmethod
-    def from_size(cls: Type["ScreenShot"], data: bytearray, width: int, height: int) -> "ScreenShot":
+    def from_size(cls: Type["ScreenShot"], data: bytearray, width: int, height: int, /) -> "ScreenShot":
         """Instantiate a new class given only screen shot's data and size."""
         monitor = {"left": 0, "top": 0, "width": width, "height": height}
         return cls(data, monitor)
@@ -126,6 +126,5 @@ class ScreenShot:
 
         try:
             return self.pixels[coord_y][coord_x]  # type: ignore
-        except IndexError:
-            # pylint: disable=raise-missing-from
-            raise ScreenShotError(f"Pixel location ({coord_x}, {coord_y}) is out of range.")
+        except IndexError as exc:
+            raise ScreenShotError(f"Pixel location ({coord_x}, {coord_y}) is out of range.") from exc

--- a/mss/tests/test_gnu_linux.py
+++ b/mss/tests/test_gnu_linux.py
@@ -2,7 +2,6 @@
 This is part of the MSS Python's module.
 Source: https://github.com/BoboTiG/python-mss
 """
-import ctypes.util
 import platform
 from unittest.mock import Mock, patch
 
@@ -88,30 +87,18 @@ def test_bad_display_structure(monkeypatch):
             pass
 
 
+@patch("mss.linux._X11", new=None)
 def test_no_xlib_library():
-    with patch("mss.linux.find_library", return_value=None):
-        with pytest.raises(ScreenShotError):
-            with mss.mss():
-                pass
+    with pytest.raises(ScreenShotError):
+        with mss.mss():
+            pass
 
 
+@patch("mss.linux._XRANDR", new=None)
 def test_no_xrandr_extension():
-    x11 = ctypes.util.find_library("X11")
-
-    def find_lib_mocked(lib):
-        """
-        Returns None to emulate no XRANDR library.
-        Returns the previous found X11 library else.
-
-        It is a naive approach, but works for now.
-        """
-
-        return None if lib == "Xrandr" else x11
-
-    # No `Xrandr` library
-    with patch("mss.linux.find_library", find_lib_mocked):
-        with pytest.raises(ScreenShotError):
-            mss.mss()
+    with pytest.raises(ScreenShotError):
+        with mss.mss():
+            pass
 
 
 @patch("mss.linux.MSS._is_extension_enabled", new=Mock(return_value=False))
@@ -190,23 +177,11 @@ def test_with_cursor(display: str):
     assert set(screenshot_with_cursor.rgb) == {0, 255}
 
 
+@patch("mss.linux._XFIXES", new=None)
 def test_with_cursor_but_not_xfixes_extension_found(display: str):
-    x11 = ctypes.util.find_library("X11")
-
-    def find_lib_mocked(lib):
-        """
-        Returns None to emulate no XRANDR library.
-        Returns the previous found X11 library else.
-
-        It is a naive approach, but works for now.
-        """
-
-        return None if lib == "Xfixes" else x11
-
-    with patch("mss.linux.find_library", find_lib_mocked):
-        with mss.mss(display=display, with_cursor=True) as sct:
-            assert not hasattr(sct, "xfixes")
-            assert not sct.with_cursor
+    with mss.mss(display=display, with_cursor=True) as sct:
+        assert not hasattr(sct, "xfixes")
+        assert not sct.with_cursor
 
 
 def test_with_cursor_failure(display: str):

--- a/mss/tests/test_issue_220.py
+++ b/mss/tests/test_issue_220.py
@@ -1,0 +1,47 @@
+"""
+This is part of the MSS Python's module.
+Source: https://github.com/BoboTiG/python-mss
+"""
+import pytest
+
+import mss
+
+tkinter = pytest.importorskip("tkinter")
+root = tkinter.Tk()
+
+
+def take_screenshot():
+    region = {"top": 370, "left": 1090, "width": 80, "height": 390}
+    with mss.mss() as sct:
+        sct.grab(region)
+
+
+def create_top_level_win():
+    top_level_win = tkinter.Toplevel(root)
+
+    take_screenshot_btn = tkinter.Button(top_level_win, text="Take screenshot", command=take_screenshot)
+    take_screenshot_btn.pack()
+
+    take_screenshot_btn.invoke()
+    root.update_idletasks()
+    root.update()
+
+    top_level_win.destroy()
+    root.update_idletasks()
+    root.update()
+
+
+def test_regression(capsys):
+    btn = tkinter.Button(root, text="Open TopLevel", command=create_top_level_win)
+    btn.pack()
+
+    # First screenshot: it works
+    btn.invoke()
+
+    # Second screenshot: it should work too
+    btn.invoke()
+
+    # Check there were no exceptions
+    captured = capsys.readouterr()
+    assert not captured.out
+    assert not captured.err

--- a/mss/tools.py
+++ b/mss/tools.py
@@ -9,7 +9,7 @@ import zlib
 from typing import Optional, Tuple
 
 
-def to_png(data: bytes, size: Tuple[int, int], level: int = 6, output: Optional[str] = None) -> Optional[bytes]:
+def to_png(data: bytes, size: Tuple[int, int], /, *, level: int = 6, output: Optional[str] = None) -> Optional[bytes]:
     """
     Dump data to a PNG file.  If `output` is `None`, create no file but return
     the whole PNG data.

--- a/mss/windows.py
+++ b/mss/windows.py
@@ -81,11 +81,7 @@ CFUNCTIONS: CFunctions = {
     "DeleteObject": ("gdi32", [HGDIOBJ], INT),
     "EnumDisplayMonitors": ("user32", [HDC, c_void_p, MONITORNUMPROC, LPARAM], BOOL),
     "GetDeviceCaps": ("gdi32", [HWND, INT], INT),
-    "GetDIBits": (
-        "gdi32",
-        [HDC, HBITMAP, UINT, UINT, c_void_p, POINTER(BITMAPINFO), UINT],
-        BOOL,
-    ),
+    "GetDIBits": ("gdi32", [HDC, HBITMAP, UINT, UINT, c_void_p, POINTER(BITMAPINFO), UINT], BOOL),
     "GetSystemMetrics": ("user32", [INT], INT),
     "GetWindowDC": ("user32", [HWND], HDC),
     "SelectObject": ("gdi32", [HDC, HGDIOBJ], HGDIOBJ),
@@ -104,7 +100,7 @@ class MSS(MSSBase):
     # A dict to maintain *srcdc* values created by multiple threads.
     _srcdc_dict: Dict[threading.Thread, int] = {}
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(self, /, **kwargs: Any) -> None:
         """Windows initialisations."""
 
         super().__init__(**kwargs)
@@ -139,12 +135,7 @@ class MSS(MSSBase):
             "user32": self.user32,
         }
         for func, (attr, argtypes, restype) in CFUNCTIONS.items():
-            cfactory(
-                attr=attrs[attr],
-                func=func,
-                argtypes=argtypes,
-                restype=restype,
-            )
+            cfactory(attrs[attr], func, argtypes, restype)
 
     def _set_dpi_awareness(self) -> None:
         """Set DPI awareness to capture full screen on Hi-DPI monitors."""
@@ -217,7 +208,7 @@ class MSS(MSSBase):
         callback = MONITORNUMPROC(_callback)
         user32.EnumDisplayMonitors(0, 0, callback, 0)
 
-    def _grab_impl(self, monitor: Monitor) -> ScreenShot:
+    def _grab_impl(self, monitor: Monitor, /) -> ScreenShot:
         """
         Retrieve all pixels from a monitor. Pixels have to be RGB.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -38,7 +37,7 @@ zip_safe = False
 include_package_data = True
 packages_dir = mss
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes #220

It is **very** important to keep up to date tests and documentation.

- [x] Tests added/updated
- [x] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
