### PR TITLE
Include documentation sources in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
-# Include tests files and data
+# Include test files, documentation sources and data
 include mss/tests/*.py
+recursive-include docs/source *
 recursive-include mss/tests/res *


### PR DESCRIPTION
### Changes proposed in this PR

Add documentation sources to the list of files included in sdist archives, in order to make it possible to build offline documentation using them.  This is necessary in order to make it possible for Linux distributions such as Gentoo to be able to use sdists.

- [ ] Tests added/updated
- [ ] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed