### PR TITLE
linux: Add failure handling to XOpenDisplay() call

### DIFF
--- a/src/mss/linux.py
+++ b/src/mss/linux.py
@@ -317,6 +317,8 @@ class MSS(MSSBase):
         self._handles.original_error_handler = self.xlib.XSetErrorHandler(_error_handler)
 
         self._handles.display = self.xlib.XOpenDisplay(display)
+        if not self._handles.display:
+            raise ScreenShotError(f"Unable to open display: {display!r}.")
 
         if not self._is_extension_enabled("RANDR"):
             raise ScreenShotError("Xrandr not enabled.")

--- a/src/tests/test_gnu_linux.py
+++ b/src/tests/test_gnu_linux.py
@@ -72,6 +72,11 @@ def test_arg_display(display: str, monkeypatch):
         with mss.mss(display="0"):
             pass
 
+    # Invalid `display` that is not trivially distinguishable.
+    with pytest.raises(ScreenShotError):
+        with mss.mss(display=":INVALID"):
+            pass
+
     # No `DISPLAY` in envars
     monkeypatch.delenv("DISPLAY")
     with pytest.raises(ScreenShotError):


### PR DESCRIPTION
Add an explicit check for the return value of XOpenDisplay().  This function does not seem to use X11 error handlers, and only returns NULL when it fails.  Without an explicit check, mss ended up passing this NULL value to further calls and causing segfaults in libX11.  Now it triggers an explicit exception instead.

### Changes proposed in this PR

- Fixes #246

It is **very** important to keep up to date tests and documentation.

- [x] Tests added/updated
- [ ] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
