### PR TITLE
dev: run tests via xvfb-run on GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,10 +88,7 @@ jobs:
         run: sudo apt install xvfb
       - name: Tests (GNU/Linux)
         if: matrix.os.emoji == '🐧'
-        run: |
-          export DISPLAY=:99
-          sudo Xvfb -ac ${DISPLAY} -screen 0 1280x1024x24 > /dev/null 2>&1 &
-          python -m pytest
+        run: xvfb-run python -m pytest
       - name: Tests (macOS, Windows)
         if: matrix.os.emoji != '🐧'
         run: python -m pytest


### PR DESCRIPTION
### Changes proposed in this PR

Use the convenience `xvfb-run` script to start Xvfb on a free DISPLAY and use it to run the test suite.  It is part of the `xvfb` package on Debian.

It is **very** important to keep up to date tests and documentation.

- [ ] Tests added/updated
- [ ] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
