### PR TITLE
tests: Use PyVirtualDisplay instead of xvfbwrapper

### DIFF
--- a/src/tests/test_leaks.py
+++ b/src/tests/test_leaks.py
@@ -94,19 +94,15 @@ def regression_issue_135():
 
 def regression_issue_210():
     """Regression test for issue #210: multiple X servers."""
-    xvfbwrapper = pytest.importorskip("xvfbwrapper")
+    pyvirtualdisplay = pytest.importorskip("pyvirtualdisplay")
 
-    vdisplay = xvfbwrapper.Xvfb(width=1920, height=1080, colordepth=24)
-    vdisplay.start()
-    with mss():
-        pass
-    vdisplay.stop()
+    with pyvirtualdisplay.Display(size=(1920, 1080), color_depth=24):
+        with mss():
+            pass
 
-    vdisplay = xvfbwrapper.Xvfb(width=1920, height=1080, colordepth=24)
-    vdisplay.start()
-    with mss():
-        pass
-    vdisplay.stop()
+    with pyvirtualdisplay.Display(size=(1920, 1080), color_depth=24):
+        with mss():
+            pass
 
 
 @pytest.mark.skipif(OS == "darwin", reason="No possible leak on macOS.")

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -3,4 +3,4 @@ pytest-cov
 numpy
 pillow
 sphinx
-xvfbwrapper; sys_platform == "linux"
+PyVirtualDisplay; sys_platform == "linux"


### PR DESCRIPTION
### Changes proposed in this PR

Use the more modern PyVirtualDisplay package instead of xvfbwrapper to run Xvfb.  Most importantly, it uses the more robust approach of starting Xvfb with `-displayfd` and it is actively maintained upstream.  Unfortunately, this does not seem sufficient to entirely eliminate random test failures.

It is **very** important to keep up to date tests and documentation.

- [ ] Tests added/updated
- [ ] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
