### PR TITLE
Use pytest-rerunfailures to rerun failing tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,3 +94,4 @@ addopts =
     -v
     --cov=mss
     --cov-report=term-missing
+    --reruns 5

--- a/tests-requirements.txt
+++ b/tests-requirements.txt
@@ -2,5 +2,6 @@ numpy
 pillow
 pytest
 pytest-cov
+pytest-rerunfailures
 pyvirtualdisplay; sys_platform == "linux"
 sphinx


### PR DESCRIPTION
### Changes proposed in this PR

Use pytest-rerunfailures plugin to attempt to rerun failing tests up to 5 times.  While this doesn't solve the underlying issue, it should keep the CI green and detecting real issues until we figure out how to solve it properly.

It is **very** important to keep up to date tests and documentation.

- [ ] Tests added/updated
- [ ] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
