### PR TITLE
Pixels model correction

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -312,9 +312,9 @@ Properties
 
     .. attribute:: pixels
 
-        List of RGB tuples.
+        List of row tuples that contain RGB tuples.
 
-        :rtype: list[tuple(int, int, int)]
+        :rtype: list[tuple(tuple(int, int, int), ...)]
 
     .. attribute:: pos
 

--- a/src/mss/models.py
+++ b/src/mss/models.py
@@ -8,7 +8,7 @@ Monitor = Dict[str, int]
 Monitors = List[Monitor]
 
 Pixel = Tuple[int, int, int]
-Pixels = List[Pixel]
+Pixels = List[Tuple[Pixel, ...]]
 
 CFunctions = Dict[str, Tuple[str, List[Any], Any]]
 

--- a/src/mss/screenshot.py
+++ b/src/mss/screenshot.py
@@ -118,7 +118,7 @@ class ScreenShot:
         :return tuple: The pixel value as (R, G, B).
         """
         try:
-            return self.pixels[coord_y][coord_x]  # type: ignore[return-value]
+            return self.pixels[coord_y][coord_x]
         except IndexError as exc:
             msg = f"Pixel location ({coord_x}, {coord_y}) is out of range."
             raise ScreenShotError(msg) from exc


### PR DESCRIPTION
### Changes proposed in this PR
ScreenShot.pixels returns a list where each element is a tuple representing a row of pixels. Each of these tuples contain "Pixel"'s. The current model incorrectly hints the return value of ScreenShot.pixels as a list containing "Pixel"s.

- Model for Pixels changed to reflect the true nature of the data

It is **very** important to keep up to date tests and documentation.

- [X] Tests added/updated
- [X] Documentation updated

Is your code right?

- [X] PEP8 compliant
- [X] `flake8` passed