### PR TITLE
docs: fix typos

### DIFF
--- a/docs/source/examples/fps_multiprocessing.py
+++ b/docs/source/examples/fps_multiprocessing.py
@@ -40,6 +40,6 @@ if __name__ == "__main__":
     # The screenshots queue
     queue: Queue = Queue()
 
-    # 2 processes: one for grabing and one for saving PNG files
+    # 2 processes: one for grabbing and one for saving PNG files
     Process(target=grab, args=(queue,)).start()
     Process(target=save, args=(queue,)).start()

--- a/docs/source/where.rst
+++ b/docs/source/where.rst
@@ -3,7 +3,7 @@ Who Uses it?
 ============
 
 This is a non exhaustive list where MSS is integrated or has inspired.
-Do not hesistate to `say Hello! <https://github.com/BoboTiG/python-mss/issues>`_ if you are using MSS too.
+Do not hesitate to `say Hello! <https://github.com/BoboTiG/python-mss/issues>`_ if you are using MSS too.
 
 - `Airtest <https://github.com/AirtestProject/Airtest>`_, a cross-platform UI automation framework for aames and apps;
 - `Automation Framework <https://github.com/capaximperii/AutomationFramework>`_, a Batmans utility;

--- a/src/mss/linux.py
+++ b/src/mss/linux.py
@@ -103,11 +103,11 @@ class XImage(Structure):
         ("bitmap_bit_order", c_int),  # LSBFirst, MSBFirst
         ("bitmap_pad", c_int),  # 8, 16, 32 either XY or ZPixmap
         ("depth", c_int),  # depth of image
-        ("bytes_per_line", c_int),  # accelarator to next line
+        ("bytes_per_line", c_int),  # accelerator to next line
         ("bits_per_pixel", c_int),  # bits per pixel (ZPixmap)
-        ("red_mask", c_ulong),  # bits in z arrangment
-        ("green_mask", c_ulong),  # bits in z arrangment
-        ("blue_mask", c_ulong),  # bits in z arrangment
+        ("red_mask", c_ulong),  # bits in z arrangement
+        ("green_mask", c_ulong),  # bits in z arrangement
+        ("blue_mask", c_ulong),  # bits in z arrangement
     )
 
 

--- a/src/tests/test_windows.py
+++ b/src/tests/test_windows.py
@@ -80,7 +80,7 @@ def run_child_thread(loops: int) -> None:
 def test_thread_safety() -> None:
     """Thread safety test for issue #150.
 
-    The following code will throw a ScreenShotError exception if thread-safety is not guaranted.
+    The following code will throw a ScreenShotError exception if thread-safety is not guaranteed.
     """
     # Let thread 1 finished ahead of thread 2
     thread1 = threading.Thread(target=run_child_thread, args=(30,))
@@ -100,7 +100,7 @@ def run_child_thread_bbox(loops: int, bbox: tuple[int, int, int, int]) -> None:
 def test_thread_safety_regions() -> None:
     """Thread safety test for different regions.
 
-    The following code will throw a ScreenShotError exception if thread-safety is not guaranted.
+    The following code will throw a ScreenShotError exception if thread-safety is not guaranteed.
     """
     thread1 = threading.Thread(target=run_child_thread_bbox, args=(100, (0, 0, 100, 100)))
     thread2 = threading.Thread(target=run_child_thread_bbox, args=(100, (0, 0, 50, 1)))


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes #
- Fix typos found via `codespell -H`


It is **very** important to keep up to date tests and documentation.

- [ ] Tests added/updated
- [x] Documentation updated

Is your code right?

- [ ] PEP8 compliant
- [ ] `flake8` passed
