### PR TITLE
fix: restore Python 3.9 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,8 @@ jobs:
           - emoji: 🪟
             runs-on: [windows-latest]
         python:
+          - name: CPython 3.9
+            runs-on: "3.9"
           - name: CPython 3.10
             runs-on: "3.10"
           - name: CPython 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ See Git checking messages for full history.
 
 ## 10.0.0 (2024-xx-xx)
 - removed support for Python 3.8
-- removed support for Python 3.9
 - added support for Python 3.14
 - :heart: contributors: @
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ with mss() as sct:
 
 An ultra-fast cross-platform multiple screenshots module in pure python using ctypes.
 
-- **Python 3.10+**, PEP8 compliant, no dependency, thread-safe;
+- **Python 3.9+**, PEP8 compliant, no dependency, thread-safe;
 - very basic, it will grab one screenshot by monitor or a screenshot of all monitors and save it to a PNG file;
 - but you can use PIL and benefit from all its formats (or add yours directly);
 - integrate well with Numpy and OpenCV;

--- a/docs/source/examples/pil_pixels.py
+++ b/docs/source/examples/pil_pixels.py
@@ -16,7 +16,7 @@ with mss.mss() as sct:
     img = Image.new("RGB", sct_img.size)
 
     # Best solution: create a list(tuple(R, G, B), ...) for putdata()
-    pixels = zip(sct_img.raw[2::4], sct_img.raw[1::4], sct_img.raw[::4], strict=False)
+    pixels = zip(sct_img.raw[2::4], sct_img.raw[1::4], sct_img.raw[::4])
     img.putdata(list(pixels))
 
     # But you can set individual pixels too (slower)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Welcome to Python MSS's documentation!
 
 An ultra fast cross-platform multiple screenshots module in pure python using ctypes.
 
-    - **Python 3.10+**, :pep:`8` compliant, no dependency, thread-safe;
+    - **Python 3.9+**, :pep:`8` compliant, no dependency, thread-safe;
     - very basic, it will grab one screenshot by monitor or a screenshot of all monitors and save it to a PNG file;
     - but you can use PIL and benefit from all its formats (or add yours directly);
     - integrate well with Numpy and OpenCV;

--- a/docs/source/support.rst
+++ b/docs/source/support.rst
@@ -5,7 +5,7 @@ Support
 Feel free to try MSS on a system we had not tested, and let us know by creating an `issue <https://github.com/BoboTiG/python-mss/issues>`_.
 
     - OS: GNU/Linux, macOS and Windows
-    - Python: 3.10 and newer
+    - Python: 3.9 and newer
 
 
 Future
@@ -35,4 +35,3 @@ Abandoned
 - Python 3.6 (2022-10-27)
 - Python 3.7 (2023-04-09)
 - Python 3.8 (2024-09-01)
-- Python 3.9 (2024-09-01)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "mss"
 description = "An ultra fast cross-platform multiple screenshots module in pure python using ctypes."
 readme = "README.md"
-requires-python = ">= 3.10"
+requires-python = ">= 3.9"
 authors = [
   { name = "Mickaël Schoentgen", email="contact@tiger-222.fr" },
 ]
@@ -31,6 +31,7 @@ classifiers = [
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -149,7 +150,7 @@ exclude = [
 ]
 line-length = 120
 indent-width = 4
-target-version = "py310"
+target-version = "py39"
 
 [tool.ruff.lint]
 extend-select = ["ALL"]

--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -39,9 +39,11 @@ class MSSBase(metaclass=ABCMeta):
         /,
         *,
         compression_level: int = 6,
-        display: bytes | str | None = None,  # noqa:ARG002 Linux only
-        max_displays: int = 32,  # noqa:ARG002 Mac only
         with_cursor: bool = False,
+        # Linux only
+        display: bytes | str | None = None,  # noqa: ARG002
+        # Mac only
+        max_displays: int = 32,  # noqa: ARG002
     ) -> None:
         self.cls_image: type[ScreenShot] = ScreenShot
         self.compression_level = compression_level

--- a/src/mss/screenshot.py
+++ b/src/mss/screenshot.py
@@ -80,8 +80,8 @@ class ScreenShot:
     def pixels(self) -> Pixels:
         """:return list: RGB tuples."""
         if not self.__pixels:
-            rgb_tuples: Iterator[Pixel] = zip(self.raw[2::4], self.raw[1::4], self.raw[::4], strict=False)
-            self.__pixels = list(zip(*[iter(rgb_tuples)] * self.width, strict=False))
+            rgb_tuples: Iterator[Pixel] = zip(self.raw[2::4], self.raw[1::4], self.raw[::4])
+            self.__pixels = list(zip(*[iter(rgb_tuples)] * self.width))
 
         return self.__pixels
 

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -116,7 +116,7 @@ def test_entry_point(with_cursor: bool, capsys: pytest.CaptureFixture) -> None:
         assert os.path.isfile("monitor-1.png")
         os.remove("monitor-1.png")
 
-    for opts in zip(["-m 1", "--monitor=1"], ["-q", "--quiet"], strict=False):
+    for opts in zip(["-m 1", "--monitor=1"], ["-q", "--quiet"]):
         main(*opts)
         captured = capsys.readouterr()
         assert not captured.out
@@ -128,7 +128,7 @@ def test_entry_point(with_cursor: bool, capsys: pytest.CaptureFixture) -> None:
         main(opt, fmt)
         captured = capsys.readouterr()
         with mss.mss(display=os.getenv("DISPLAY")) as sct:
-            for mon, (monitor, line) in enumerate(zip(sct.monitors[1:], captured.out.splitlines(), strict=False), 1):
+            for mon, (monitor, line) in enumerate(zip(sct.monitors[1:], captured.out.splitlines()), 1):
                 filename = fmt.format(mon=mon, **monitor)
                 assert line.endswith(filename)
                 assert os.path.isfile(filename)


### PR DESCRIPTION
It can wait for its official unsupport before unsupporting it here.