### PR TITLE
feat: window capture (Mac)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,16 @@ with mss() as sct:
 An ultra-fast cross-platform multiple screenshots module in pure python using ctypes.
 
 - **Python 3.9+**, PEP8 compliant, no dependency, thread-safe;
-- very basic, it will grab one screenshot by monitor or a screenshot of all monitors and save it to a PNG file;
+- very basic, it will grab one screenshot by monitor or window, or a screenshot of all monitors and save it to a PNG file;
 - but you can use PIL and benefit from all its formats (or add yours directly);
 - integrate well with Numpy and OpenCV;
 - it could be easily embedded into games and other software which require fast and platform optimized methods to grab screenshots (like AI, Computer Vision);
 - get the [source code on GitHub](https://github.com/BoboTiG/python-mss);
 - learn with a [bunch of examples](https://python-mss.readthedocs.io/examples.html);
 - you can [report a bug](https://github.com/BoboTiG/python-mss/issues);
-- need some help? Use the tag *python-mss* on [Stack Overflow](https://stackoverflow.com/questions/tagged/python-mss);
+- need some help? Use the tag _python-mss_ on [Stack Overflow](https://stackoverflow.com/questions/tagged/python-mss);
 - and there is a [complete, and beautiful, documentation](https://python-mss.readthedocs.io) :)
 - **MSS** stands for Multiple ScreenShots;
-
 
 ## Installation
 

--- a/src/mss/__main__.py
+++ b/src/mss/__main__.py
@@ -31,7 +31,9 @@ def main(*args: str) -> int:
         help="the PNG compression level",
     )
     cli_args.add_argument("-m", "--monitor", default=0, type=int, help="the monitor to screenshot")
-    cli_args.add_argument("-o", "--output", default="monitor-{mon}.png", help="the output file name")
+    cli_args.add_argument("-w", "--window", default=None, help="the window to screenshot")
+    cli_args.add_argument("-p", "--process", default=None, help="the process to screenshot")
+    cli_args.add_argument("-o", "--output", default=None, help="the output file name")
     cli_args.add_argument("--with-cursor", default=False, action="store_true", help="include the cursor")
     cli_args.add_argument(
         "-q",
@@ -43,7 +45,8 @@ def main(*args: str) -> int:
     cli_args.add_argument("-v", "--version", action="version", version=__version__)
 
     options = cli_args.parse_args(args or None)
-    kwargs = {"mon": options.monitor, "output": options.output}
+    output = options.output or ("window-{win}.png" if options.window or options.process else "monitor-{mon}.png")
+    kwargs = {"mon": options.monitor, "output": output, "win": options.window, "proc": options.process}
     if options.coordinates:
         try:
             top, left, width, height = options.coordinates.split(",")

--- a/src/mss/models.py
+++ b/src/mss/models.py
@@ -7,10 +7,14 @@ from typing import Any, NamedTuple
 Monitor = dict[str, int]
 Monitors = list[Monitor]
 
+Window = dict[str, Any]
+Windows = list[Window]
+
 Pixel = tuple[int, int, int]
 Pixels = list[tuple[Pixel, ...]]
 
 CFunctions = dict[str, tuple[str, list[Any], Any]]
+CConstants = dict[str, Any]
 
 
 class Pos(NamedTuple):

--- a/src/tests/test_find_windows.py
+++ b/src/tests/test_find_windows.py
@@ -1,0 +1,9 @@
+"""This is part of the MSS Python's module.
+Source: https://github.com/BoboTiG/python-mss.
+"""
+
+from mss import mss
+
+def test_get_windows() -> None:
+    with mss() as sct:
+        assert sct.windows


### PR DESCRIPTION
### Changes proposed in this PR

- Fixes #331
- I've spent a long time deciding how fields should be included in `Window` type as all of those fields should be implemented on other platforms as well. Finally, I found that, at least on Windows, window name, process name, and window bounds can be implemented easily. If you have any different opinions, please feel free to share them.
- Even though there are additioanl tests for my implementation, I think they aren't sufficient. However, I'm not sure how to properly verify my codes, as the results directly depend on current windows and processes.  would appreciate any suggestions on better approaches.
- This PR includes only the OSX implementation, and additional development is needed for Windows and Linux.

It is **very** important to keep up to date tests and documentation.

- [x] Tests added/updated
- [x] Documentation updated

Is your code right?

- [x] PEP8 compliant
- [x] `flake8` passed
