### PR TITLE
Use a more targeted lsof invocation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,8 @@ ignore = [
   "FBT001",   # boolean-typed positional argument in function definition
   "PLR2004",  # magic value used in comparison
   "S101",     # use of `assert` detected
-  "S602",     # `subprocess` call with `shell=True`
-  "S603",     # `subprocess` call
+  #"S602",     # `subprocess` call with `shell=True`
+  "S603",     # `subprocess` call: check for execution of untrusted input
+  "S607",     # `subprocess` call without explicit paths
   "SLF001",   # private member accessed
 ]

--- a/src/tests/test_leaks.py
+++ b/src/tests/test_leaks.py
@@ -20,9 +20,9 @@ def get_opened_socket() -> int:
     """GNU/Linux: a way to get the opened sockets count.
     It will be used to check X server connections are well closed.
     """
-    cmd = f"lsof -U | grep {PID}"
-    output = subprocess.check_output(cmd, shell=True)
-    return len(output.splitlines())
+    output = subprocess.check_output(["lsof", "-a", "-U", "-Ff", f"-p{PID}"])
+    # The first line will be "p{PID}".  The remaining lines start with "f", one per open socket.
+    return len([line for line in output.splitlines() if line.startswith(b"f")])
 
 
 def get_handles() -> int:


### PR DESCRIPTION
I was getting some false hits with lsof | grep $PID.  We can use lsof -p $PID instead.