### PR TITLE
Re-enable ruff check S602

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,7 @@ ignore = [
   "FBT001",   # boolean-typed positional argument in function definition
   "PLR2004",  # magic value used in comparison
   "S101",     # use of `assert` detected
-  #"S602",     # `subprocess` call with `shell=True`
+  "S602",     # `subprocess` call with `shell=True`
   "S603",     # `subprocess` call: check for execution of untrusted input
   "S607",     # `subprocess` call without explicit paths
   "SLF001",   # private member accessed


### PR DESCRIPTION
I disabled this temporarily while developing something else, but forgot to re-enable it.

Apologies!

### Changes proposed in this PR

- Fixes no issues

It is **very** important to keep up to date tests and documentation.

- [x] Tests added/updated : nothing to test
- [x] Documentation updated : nothing to document

Is your code right?

- [x] `./check.sh` passed : existing code was fine with the newly-enabled test
