### PR TITLE
Fix object release in macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See Git checking messages for full history.
 - Linux: introduce an XCB-powered backend stack with a factory in ``mss.linux`` while keeping the Xlib code as a fallback (#425)
 - Linux: add the XShmGetImage backend with automatic XGetImage fallback and explicit status reporting (#431)
 - Windows: improve error checking and messages for Win32 API calls (#448)
+- Mac: fix memory leak (#450, #453)
 - :heart: contributors: @jholveck
 
 ## 10.1.0 (2025-08-16)

--- a/src/mss/darwin.py
+++ b/src/mss/darwin.py
@@ -90,7 +90,6 @@ CFUNCTIONS: CFunctions = {
     "CFDataGetBytePtr": ("core", [c_void_p], POINTER(c_ubyte)),
     "CFDataGetLength": ("core", [c_void_p], c_long),
     "CFRelease": ("core", [c_void_p], None),
-    "CGDataProviderRelease": ("core", [c_void_p], None),
     "CGGetActiveDisplayList": ("core", [c_uint32, POINTER(c_uint32), POINTER(c_uint32)], c_int32),
     "CGImageGetBitsPerPixel": ("core", [c_void_p], c_size_t),
     "CGImageGetBytesPerRow": ("core", [c_void_p], c_size_t),


### PR DESCRIPTION
Previously, we would release the image data provider, but not the image.  We actually need to release the image, and not the data provider.  This is based on the CoreFoundation "Create/Copy/Get" ownership rules: we own things that we allocate with functions with Create or Copy in their name, but not things that have Get in their name.

I suspect that the CGImage held a reference to its data provider, which stored the pixel data.  When we freed the data provider, we released the pixel data, but not the CGImage structure.

Now, we're releasing the CGImage, and it releases the data provider.

Empirical testing while taking 10000 successive screenshots showed that, once steady state was reached, the previous version was leaking an average of about 467 bytes per screenshot on average.  The new version still leaks about 148 bytes per screenshot, although that may not be related to macOS.

Also fixed a few function types, but those were harmless.

### Changes proposed in this PR

- Fixes #450

It is **very** important to keep up to date tests and documentation.

- [ ] Tests added/updated  (N/A)
- [ ] Documentation updated  (N/A)

Is your code right?

- [x] `./check.sh` passed
