### PR TITLE
Fix tests so they work with all multi-monitor setups

### DIFF
--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -186,9 +186,6 @@ class MSSBase(metaclass=ABCMeta):
                 "height": monitor[3] - monitor[1],
             }
 
-        if monitor["left"] < 0 or monitor["top"] < 0:
-            msg = f"Region has negative coordinates: {monitor!r}"
-            raise ScreenShotError(msg)
         if monitor["width"] <= 0 or monitor["height"] <= 0:
             msg = f"Region has zero or negative size: {monitor!r}"
             raise ScreenShotError(msg)

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -255,23 +255,15 @@ def test_grab_with_tuple(mss_impl: Callable[..., MSSBase]) -> None:
 def test_grab_with_invalid_tuple(mss_impl: Callable[..., MSSBase]) -> None:
     with mss_impl() as sct:
         # Remember that rect tuples are PIL-style: (left, top, right, bottom)
+        # Negative left/top coordinates are valid for multi-monitor setups
+        # where monitors can be positioned to the left of or above the primary.
 
-        # Negative top
-        negative_box = (100, -100, 500, 500)
-        with pytest.raises(ScreenShotError):
-            sct.grab(negative_box)
-
-        # Negative left
-        negative_box = (-100, 100, 500, 500)
-        with pytest.raises(ScreenShotError):
-            sct.grab(negative_box)
-
-        # Negative width (but right > 0)
+        # Negative width (right < left)
         negative_box = (100, 100, 50, 500)
         with pytest.raises(ScreenShotError):
             sct.grab(negative_box)
 
-        # Negative height (but bottom > 0)
+        # Negative height (bottom < top)
         negative_box = (100, 100, 500, 50)
         with pytest.raises(ScreenShotError):
             sct.grab(negative_box)


### PR DESCRIPTION
The setup of having a monitor to the left or above the primary monitor was not working correctly.  A number of tests would fail.

### Changes proposed in this PR

This fixes 25 test failures I would otherwise get on my multi-monitor Windows machine.  These changes are internally facing and therefore do not warrant a CHANGELOG.md entry or documentation update.

- [x] Tests added/updated
- [x] `./check.sh` passed
