### PR TITLE
Note in docstring that _merge expects straight alpha

### DIFF
--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -278,7 +278,10 @@ class MSSBase(metaclass=ABCMeta):
 
     @staticmethod
     def _merge(screenshot: ScreenShot, cursor: ScreenShot, /) -> ScreenShot:
-        """Create composite image by blending screenshot and mouse cursor."""
+        """Create composite image by blending screenshot and mouse cursor.
+
+        The cursor image should be in straight (not premultiplied) alpha.
+        """
         (cx, cy), (cw, ch) = cursor.pos, cursor.size
         (x, y), (w, h) = screenshot.pos, screenshot.size
 


### PR DESCRIPTION
Currently, the _merge method expects straight (not premultiplied) alpha.  That's what XFixes sends, and that's the only way we get cursor images today, so that's ok.

In the future, we might want to switch to using premultiplied alpha.  It's easier to composite, and it's just as fast in the case where we get straight alpha and faster (and easier) if we get premultiplied alpha.

On the other hand, on non-Linux platforms, we might prefer to merge the cursor differently, such as with DrawIconEx, so we might change cursor handling altogether.