### PR TITLE
Demo video-capture width and height must be divisible by 2

### DIFF
--- a/demos/video-capture-simple.py
+++ b/demos/video-capture-simple.py
@@ -78,8 +78,8 @@ def main() -> None:
             video_stream = avmux.add_stream(CODEC, rate=FPS, options=CODEC_OPTIONS)
             # Width and height must be divisible by 2, otherwise the encoder will fail.
             # Round down to the nearest even number.
-            video_stream.width = monitor["width"] & ~1
-            video_stream.height = monitor["height"] & ~1
+            video_stream.width = monitor["width"] // 2 * 2
+            video_stream.height = monitor["height"] // 2 * 2
             # There are more options you can set on the video stream; the full demo uses some of those.
 
             # Count how many frames we're capturing, so we can log the FPS later.

--- a/demos/video-capture.py
+++ b/demos/video-capture.py
@@ -478,8 +478,8 @@ def main() -> None:
 
             # Width and height must be divisible by 2, otherwise the encoder will fail.
             # Round down to the nearest even number.
-            video_stream.width = monitor["width"] & ~1
-            video_stream.height = monitor["height"] & ~1
+            video_stream.width = monitor["width"] // 2 * 2
+            video_stream.height = monitor["height"] // 2 * 2
             # There are multiple time bases in play (stream, codec context, per-frame).  Depending on the container
             # and codec, some of these might be ignored or overridden.  We set the desired time base consistently
             # everywhere, so that the saved timestamps are correct regardless of what format we're saving to.


### PR DESCRIPTION
When the resolution is not an even number, it generates an error:
```
 File "av/codec/context.pyx", line 200, in av.codec.context.CodecContext.open                                                                                                                           
    File "av/codec/context.pyx", line 220, in av.codec.context.CodecContext.open                                                                                                                           
    File "av/error.pyx", line 424, in av.error.err_check                                                                                                                                                   
  av.error.ExternalError: [Errno 542398533] Generic error in an external library: 'avcodec_open2(libx264)'; last error log: [libx264] height not divisible by 2 (1512x949)
```

### Changes proposed in this PR

Fixes #
Width and height must be divisible by 2, otherwise the encoder will fail. Round down to the nearest even number.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Changelog entry added
- [ ] `./check.sh` passed
