### PR TITLE
Demo video-capture: Crop size to a multiple of two

### DIFF
--- a/demos/video-capture-simple.py
+++ b/demos/video-capture-simple.py
@@ -71,6 +71,11 @@ def main() -> None:
     with mss.mss() as sct:
         monitor = sct.monitors[1]
 
+        # Because of how H.264 video stores color information, libx264 requires the video size to be a multiple of
+        # two.        
+        monitor["width"] = (monitor["width"] // 2) * 2
+        monitor["height"] = (monitor["height"] // 2) * 2
+
         with av.open(FILENAME, "w") as avmux:
             # The "avmux" object we get back from "av.open" represents the MP4 file.  That's a container that holds
             # the video, as well as possibly audio and more.  These are each called "streams".  We only create one


### PR DESCRIPTION
To accommodate 4:2:0 subsampling, libx264 and libx265 require the video size to be a multiple of two.  Add that behavior, with a flag to adjust it in the full demo.

See also #472 

### Changes proposed in this PR

Fixes #
Width and height must be divisible by 2, otherwise the encoder will fail. Round down to the nearest even number.

- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Changelog entry added
- [ ] `./check.sh` passed
