### PR TITLE
fix(windows): Lazy-init desktop and memory DCs

### DIFF
--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -18,6 +18,8 @@ The MSS project has chosen to end support for Python 3.9, in order to focus our 
 
 Improved error handling when interacting with Win32 API, which will improve diagnostics of issues.
 
+Device contexts are now acquired and released within each `grab()` call, allowing monitor enumeration to work even when `GetWindowDC(0)` fails (#509).
+
 ### General Improvements
 
 The MSS context object will now always surface inner exceptions, even if `__exit__` may also generate an exception during tear-down.

--- a/src/mss/windows/gdi.py
+++ b/src/mss/windows/gdi.py
@@ -205,9 +205,7 @@ class MSSImplGdi(MSSImplementation):
         "_dib",
         "_dib_array",
         "_dib_bits",
-        "_memdc",
         "_region_width_height",
-        "_srcdc",
         "gdi32",
         "user32",
     }
@@ -226,8 +224,6 @@ class MSSImplGdi(MSSImplementation):
         self._dib: HBITMAP | None = None
         self._dib_bits: LPVOID = LPVOID()  # Pointer to DIB pixel data
         self._dib_array: ctypes.Array[ctypes.c_char] | None = None  # Cached array view of DIB memory
-        self._srcdc = self.user32.GetWindowDC(0)
-        self._memdc = self.gdi32.CreateCompatibleDC(self._srcdc)
 
         bmi = BITMAPINFO()
         bmi.bmiHeader.biSize = ctypes.sizeof(BITMAPINFOHEADER)
@@ -243,18 +239,9 @@ class MSSImplGdi(MSSImplementation):
         self._bmi = bmi
 
     def close(self) -> None:
-        # Clean-up
         if self._dib:
             self.gdi32.DeleteObject(self._dib)
             self._dib = None
-
-        if self._memdc:
-            self.gdi32.DeleteDC(self._memdc)
-            self._memdc = None
-
-        if self._srcdc:
-            self.user32.ReleaseDC(0, self._srcdc)
-            self._srcdc = None
 
     def _set_cfunctions(self) -> None:
         """Set all ctypes functions and attach them to attributes."""
@@ -357,9 +344,10 @@ class MSSImplGdi(MSSImplementation):
     def grab(self, monitor: Monitor, /) -> bytearray:
         """Retrieve all pixels from a monitor using CreateDIBSection.
 
-        CreateDIBSection creates a DIB with system-managed memory backing,
-        allowing BitBlt to write directly to memory we can read. This eliminates
-        the need for a separate GetDIBits call.
+        Device contexts (srcdc / memdc) are acquired and released within each
+        call.  This avoids holding GDI resources across threads and allows
+        ``MSS()`` construction to succeed even when ``GetWindowDC(0)`` would
+        fail (locked screen, UAC, RDP).  See issue #509.
 
         Note on biHeight: A bottom-up DIB is specified by setting the height to a
         positive number, while a top-down DIB is specified by setting the height
@@ -367,47 +355,55 @@ class MSSImplGdi(MSSImplementation):
         https://learn.microsoft.com/en-us/windows/win32/api/wingdi/ns-wingdi-bitmapinfoheader
         https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createdibsection
         """
-        srcdc, memdc = self._srcdc, self._memdc
         gdi = self.gdi32
-        width, height = monitor["width"], monitor["height"]
+        srcdc = self.user32.GetWindowDC(0)
+        try:
+            memdc = gdi.CreateCompatibleDC(srcdc)
+            try:
+                width, height = monitor["width"], monitor["height"]
 
-        if self._region_width_height != (width, height):
-            self._region_width_height = (width, height)
-            self._bmi.bmiHeader.biWidth = width
-            self._bmi.bmiHeader.biHeight = -height  # Negative for top-down DIB
+                if self._region_width_height != (width, height):
+                    self._region_width_height = (width, height)
+                    self._bmi.bmiHeader.biWidth = width
+                    self._bmi.bmiHeader.biHeight = -height  # Negative for top-down DIB
 
-            if self._dib:
-                gdi.DeleteObject(self._dib)
-                self._dib = None
+                    if self._dib:
+                        gdi.DeleteObject(self._dib)
+                        self._dib = None
 
-            # CreateDIBSection creates the DIB and returns a pointer to the pixel data
-            self._dib_bits = LPVOID()
-            self._dib = gdi.CreateDIBSection(
-                memdc,
-                self._bmi,
-                DIB_RGB_COLORS,
-                ctypes.byref(self._dib_bits),
-                None,  # hSection = NULL (system allocates memory)
-                0,  # offset = 0
-            )
-            gdi.SelectObject(memdc, self._dib)
+                    # CreateDIBSection creates the DIB and returns a pointer to the pixel data
+                    self._dib_bits = LPVOID()
+                    self._dib = gdi.CreateDIBSection(
+                        memdc,
+                        self._bmi,
+                        DIB_RGB_COLORS,
+                        ctypes.byref(self._dib_bits),
+                        None,  # hSection = NULL (system allocates memory)
+                        0,  # offset = 0
+                    )
 
-            # Create a ctypes array type that maps directly to the DIB memory.
-            # This avoids the overhead of ctypes.string_at() creating an intermediate bytes object.
-            size = width * height * 4
-            array_type = ctypes.c_char * size
-            self._dib_array = ctypes.cast(self._dib_bits, POINTER(array_type)).contents
+                    # Create a ctypes array type that maps directly to the DIB memory.
+                    # This avoids the overhead of ctypes.string_at() creating an intermediate bytes object.
+                    size = width * height * 4
+                    array_type = ctypes.c_char * size
+                    self._dib_array = ctypes.cast(self._dib_bits, POINTER(array_type)).contents
 
-        # BitBlt copies screen content directly into the DIB's memory
-        gdi.BitBlt(memdc, 0, 0, width, height, srcdc, monitor["left"], monitor["top"], SRCCOPY | CAPTUREBLT)
+                # Select the cached DIB into the per-call memdc so BitBlt writes into it.
+                gdi.SelectObject(memdc, self._dib)
 
-        # Flush GDI operations to ensure DIB memory is fully updated before reading.
-        # This ensures the BitBlt has completed before we access the memory.
-        gdi.GdiFlush()
+                # BitBlt copies screen content directly into the DIB's memory
+                gdi.BitBlt(memdc, 0, 0, width, height, srcdc, monitor["left"], monitor["top"], SRCCOPY | CAPTUREBLT)
 
-        # Read directly from DIB memory via the cached array view
-        assert self._dib_array is not None  # noqa: S101  for type checker
-        return bytearray(self._dib_array)
+                # Flush GDI operations to ensure DIB memory is fully updated before reading.
+                gdi.GdiFlush()
+
+                # Read directly from DIB memory via the cached array view
+                assert self._dib_array is not None  # noqa: S101  for type checker
+                return bytearray(self._dib_array)
+            finally:
+                gdi.DeleteDC(memdc)
+        finally:
+            self.user32.ReleaseDC(0, srcdc)
 
     def cursor(self) -> None:
         """Retrieve all cursor data. Pixels have to be RGB."""

--- a/src/tests/bench_grab_windows.py
+++ b/src/tests/bench_grab_windows.py
@@ -109,36 +109,40 @@ def benchmark_raw_bitblt() -> None:
     srccopy = 0x00CC0020
     captureblt = 0x40000000
 
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+
     with mss.MSS() as sct:
         monitor = sct.monitors[1]
         width, height = monitor["width"], monitor["height"]
         left, top = monitor["left"], monitor["top"]
 
-        # Force region setup
-        sct.grab(monitor)
-
-        assert isinstance(sct._impl, mss.windows.gdi.MSSImplGdi)
-        srcdc = sct._impl._srcdc
-        memdc = sct._impl._memdc
+        # Acquire DCs directly for raw benchmarking (the impl no longer
+        # holds them as instance state — they are per-grab now).
+        srcdc = user32.GetWindowDC(0)
+        memdc = gdi32.CreateCompatibleDC(srcdc)
 
         print(f"Raw BitBlt benchmark ({width}x{height})")
         print("=" * 50)
 
-        # Test with CAPTUREBLT
-        start = perf_counter()
-        for _ in range(ITERATIONS):
-            bitblt(memdc, 0, 0, width, height, srcdc, left, top, srccopy | captureblt)
-            gdiflush()
-        elapsed = perf_counter() - start
-        print(f"With CAPTUREBLT:    {elapsed / ITERATIONS * 1000:.2f}ms ({ITERATIONS / elapsed:.1f} FPS)")
+        try:
+            # Test with CAPTUREBLT
+            start = perf_counter()
+            for _ in range(ITERATIONS):
+                bitblt(memdc, 0, 0, width, height, srcdc, left, top, srccopy | captureblt)
+                gdiflush()
+            elapsed = perf_counter() - start
+            print(f"With CAPTUREBLT:    {elapsed / ITERATIONS * 1000:.2f}ms ({ITERATIONS / elapsed:.1f} FPS)")
 
-        # Test without CAPTUREBLT
-        start = perf_counter()
-        for _ in range(ITERATIONS):
-            bitblt(memdc, 0, 0, width, height, srcdc, left, top, srccopy)
-            gdiflush()
-        elapsed = perf_counter() - start
-        print(f"Without CAPTUREBLT: {elapsed / ITERATIONS * 1000:.2f}ms ({ITERATIONS / elapsed:.1f} FPS)")
+            # Test without CAPTUREBLT
+            start = perf_counter()
+            for _ in range(ITERATIONS):
+                bitblt(memdc, 0, 0, width, height, srcdc, left, top, srccopy)
+                gdiflush()
+            elapsed = perf_counter() - start
+            print(f"Without CAPTUREBLT: {elapsed / ITERATIONS * 1000:.2f}ms ({ITERATIONS / elapsed:.1f} FPS)")
+        finally:
+            gdi32.DeleteDC(memdc)
+            user32.ReleaseDC(0, srcdc)
 
 
 def analyze_frame_timing() -> None:

--- a/src/tests/test_windows.py
+++ b/src/tests/test_windows.py
@@ -145,23 +145,30 @@ def test_region_not_caching() -> None:
     assert dib1 != dib2
 
 
-def test_monitors_without_grab() -> None:
+def test_monitors_work_when_getwindowdc_fails() -> None:
     """Regression test for issue #509.
 
-    Constructing ``MSS`` and reading ``sct.monitors`` must not call
-    ``GetWindowDC(0)``.  Device contexts are only needed for ``grab()``.
+    ``GetWindowDC(0)`` can fail (locked screen, UAC, RDP, GDI pressure).
+    Enumerating monitors must still work because it only needs
+    ``EnumDisplayMonitors`` / ``GetMonitorInfoW``.
     """
     with mss.MSS() as sct:
         impl = sct._impl
         assert isinstance(impl, MSSImplGdi)
 
-        # DCs are no longer instance attributes.
-        assert not hasattr(impl, "_srcdc")
-        assert not hasattr(impl, "_memdc")
+        # Simulate GetWindowDC failing — grab() should raise, but
+        # monitors must remain accessible.
+        original = impl.user32.GetWindowDC
+        impl.user32.GetWindowDC = lambda _hwnd: 0  # type: ignore[attr-defined]
+        try:
+            monitors = sct.monitors
+            assert len(monitors) >= 1
+            assert "width" in monitors[0]
 
-        monitors = sct.monitors
-        assert len(monitors) >= 1
-        assert "width" in monitors[0]
+            with pytest.raises(ScreenShotError):
+                sct.grab(monitors[1])
+        finally:
+            impl.user32.GetWindowDC = original  # type: ignore[attr-defined]
 
 
 def run_child_thread(loops: int) -> None:

--- a/src/tests/test_windows.py
+++ b/src/tests/test_windows.py
@@ -145,6 +145,25 @@ def test_region_not_caching() -> None:
     assert dib1 != dib2
 
 
+def test_monitors_without_grab() -> None:
+    """Regression test for issue #509.
+
+    Constructing ``MSS`` and reading ``sct.monitors`` must not call
+    ``GetWindowDC(0)``.  Device contexts are only needed for ``grab()``.
+    """
+    with mss.MSS() as sct:
+        impl = sct._impl
+        assert isinstance(impl, MSSImplGdi)
+
+        # DCs are no longer instance attributes.
+        assert not hasattr(impl, "_srcdc")
+        assert not hasattr(impl, "_memdc")
+
+        monitors = sct.monitors
+        assert len(monitors) >= 1
+        assert "width" in monitors[0]
+
+
 def run_child_thread(loops: int) -> None:
     for _ in range(loops):
         with mss.MSS() as sct:  # New sct for every loop


### PR DESCRIPTION
Fixes #509.

### Problem

`MSSImplGdi.__init__` unconditionally calls `GetWindowDC(0)` and `CreateCompatibleDC` at `src/mss/windows/gdi.py:208-209`. Both can fail with `WinError 5: Access is denied` under:

- Locked screen / session switch
- UAC prompt in the foreground
- RDP disconnect
- GDI handle pressure (the process has approached the per-process limit)

As a result, even read-only use like `with mss.MSS() as sct: sct.monitors` crashes in these environments — despite `monitors()` only needing `EnumDisplayMonitors` / `GetMonitorInfoW`, neither of which requires a desktop DC.

### Fix

Defer `GetWindowDC(0)` and `CreateCompatibleDC` to the first `grab()` call via a new `_ensure_dcs()` helper. `close()` already guards on `None`, so no cleanup changes are needed. The change is backwards compatible — `grab()` still works identically; the DCs are just created on demand.

### Test plan

- [x] Added `test_monitors_does_not_call_getwindowdc` in `src/tests/test_windows.py` that wraps `GetWindowDC` with an assertion so any call during `sct.monitors` fails the test.
- [x] `ruff check` passes
- [x] `ruff format --check` passes
- [x] Existing non-Windows tests still pass locally on macOS (77 passed, 52 skipped — Windows/Linux-specific).
- [ ] Existing Windows tests still pass in CI (maintainer to verify).