### PR TITLE
docs: fix examples link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ An ultra-fast cross-platform multiple screenshots module in pure python using ct
 - integrate well with Numpy and OpenCV;
 - it could be easily embedded into games and other software which require fast and platform optimized methods to grab screenshots (like AI, Computer Vision);
 - get the [source code on GitHub](https://github.com/BoboTiG/python-mss);
-- learn with a [bunch of examples](https://python-mss.readthedocs.io/examples.html);
+- learn with a [bunch of examples](https://python-mss.readthedocs.io/stable/examples.html);
 - you can [report a bug](https://github.com/BoboTiG/python-mss/issues);
 - need some help? Use the tag *python-mss* on [Stack Overflow](https://stackoverflow.com/questions/tagged/python-mss);
 - and there is a [complete, and beautiful, documentation](https://python-mss.readthedocs.io) :)


### PR DESCRIPTION
### Changes proposed in this PR
update the examples link to point to the stable version instead of nowhere

- [ ] Tests added/updated
- [x] Documentation updated
- [ ] Changelog entry added
- [ ] `./check.sh` passed
