### PR TITLE
Pin hatchling to 1.29.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling==1.29.0"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
About an hour ago, a new version of our build system, Hatchling (1.30.0), was released.  This sets the metadata-version to 2.5.  But that version is not supported by Twine, our PyPI upload system.

I haven't researched if there's a better option, but this should deal with the immediate problem.  At the least, we should update Hatchling once Twine is able to handle 2.5.