### PR TITLE
Fix Pillow examples using frombuffer

### DIFF
--- a/demos/cat-detector.py
+++ b/demos/cat-detector.py
@@ -281,7 +281,7 @@ def main() -> None:
             # We transfer the image from MSS to PyTorch via a Pillow Image.  Faster approaches exist (see
             # screenshot_to_tensor), but PIL is more readable.  The bulk of the time in this program is spent doing
             # the AI work, so we just use the most convenient mechanism.
-            img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
+            img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX", 0, 1)
 
             # We explicitly convert it to a tensor here, even though Torchvision can also convert it in the preprocess
             # step.  This is so that we send it to the GPU before we do the preprocessing: PIL Images are always on

--- a/demos/tinytv-stream-simple.py
+++ b/demos/tinytv-stream-simple.py
@@ -97,7 +97,7 @@ def main() -> None:
                     # The next step is to resize the image to fit the TinyTV's screen.  There's a great image
                     # manipulation library called PIL, or Pillow, that can do that.  Let's transfer the raw pixels in
                     # the ScreenShot object into a PIL Image.
-                    original_image = Image.frombuffer("RGB", screenshot.size, screenshot.bgra, "raw", "BGRX")
+                    original_image = Image.frombuffer("RGB", screenshot.size, screenshot.bgra, "raw", "BGRX", 0, 1)
 
                     # Now, we can resize it.  The resize method may stretch the image to make it match the TinyTV's
                     # screen; the advanced demo gives other options.  Using a reducing gap is optional, but speeds up

--- a/demos/tinytv-stream.py
+++ b/demos/tinytv-stream.py
@@ -348,7 +348,7 @@ def capture_image(
 
         while True:
             sct_img = sct.grab(rect)
-            pil_img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
+            pil_img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX", 0, 1)
             yield pil_img
 
 

--- a/demos/video-capture-simple.py
+++ b/demos/video-capture-simple.py
@@ -129,7 +129,7 @@ def main() -> None:
                 # use PIL: you can create an Image from the screenshot, and create a VideoFrame from that.  That said,
                 # if you want to boost the fps rate by about 50%, check out the full demo, and search for
                 # from_numpy_buffer.
-                img = Image.frombuffer("RGB", screenshot.size, screenshot.bgra, "raw", "BGRX")
+                img = Image.frombuffer("RGB", screenshot.size, screenshot.bgra, "raw", "BGRX", 0, 1)
                 frame = av.VideoFrame.from_image(img)
 
                 # When we encode frames, we get back a list of packets.  Often, we'll get no packets at first: the

--- a/docs/source/examples/pil.py
+++ b/docs/source/examples/pil.py
@@ -15,9 +15,9 @@ with mss.MSS() as sct:
         sct_img = sct.grab(monitor)
 
         # Create the Image
-        img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
+        img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX", 0, 1)
         # The same, but less efficient:
-        # img = Image.frombuffer('RGB', sct_img.size, sct_img.rgb, 'raw', 'RGB')
+        # img = Image.frombuffer('RGB', sct_img.size, sct_img.rgb, 'raw', 'RGB', 0, 1)
 
         # And save it!
         output = f"monitor-{num}.png"

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -15,8 +15,7 @@ writing, but should be by the time we release 11.0!)
 
 #### ScreenShot attributes
 
-The {py:attr}`mss.ScreenShot.raw` attribute has been deprecated, and will soon be removed.  Use the
-{py:attr}`mss.ScreenShot.bgra` property instead.
+The {py:attr}`mss.ScreenShot.raw` attribute has been removed.  Use the {py:attr}`mss.ScreenShot.bgra` property instead.
 
 The {py:attr}`mss.ScreenShot.bgra` and {py:attr}`mss.ScreenShot.rgb` properties now will return read-only bytes-like
 {py:type}`memoryview` objects, not necessarily {py:type}`bytes` or {py:type}`bytearray` objects.  For practical use

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -43,4 +43,4 @@ The MSS context object will now always surface inner exceptions, even if `__exit
 The documentation has received numerous small improvements.  A few highlights:
 
 * The Pillow examples and demos using {py:meth}`PIL.Image.frombuffer` now explicitly specify the decoder arguments,
-  as recommended by Pillow.
+  as recommended by Pillow.  (#535)

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -15,7 +15,8 @@ writing, but should be by the time we release 11.0!)
 
 #### ScreenShot attributes
 
-The {py:attr}`mss.ScreenShot.raw` attribute has been removed.  Use the {py:attr}`mss.ScreenShot.bgra` property instead.
+The {py:attr}`mss.ScreenShot.raw` attribute has been deprecated, and will soon be removed.  Use the
+{py:attr}`mss.ScreenShot.bgra` property instead.
 
 The {py:attr}`mss.ScreenShot.bgra` and {py:attr}`mss.ScreenShot.rgb` properties now will return read-only bytes-like
 {py:type}`memoryview` objects, not necessarily {py:type}`bytes` or {py:type}`bytearray` objects.  For practical use
@@ -36,3 +37,10 @@ Device contexts are now acquired and released within each `grab()` call, allowin
 ### General Improvements
 
 The MSS context object will now always surface inner exceptions, even if `__exit__` may also generate an exception during tear-down.
+
+### Documentation
+
+The documentation has received numerous small improvements.  A few highlights:
+
+* The Pillow examples and demos using {py:meth}`PIL.Image.frombuffer` now explicitly specify the decoder arguments,
+  as recommended by Pillow.

--- a/src/tests/third_party/test_pil.py
+++ b/src/tests/third_party/test_pil.py
@@ -37,7 +37,7 @@ def test_pil_bgra(mss_impl: Callable[..., MSS]) -> None:
     with mss_impl() as sct:
         sct_img = sct.grab(box)
 
-    img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX")
+    img = Image.frombuffer("RGB", sct_img.size, sct_img.bgra, "raw", "BGRX", 0, 1)
     assert img.mode == "RGB"
     assert img.size == sct_img.size
 


### PR DESCRIPTION
The Pillow docs recommend always using the decoder arguments when using frombuffer; see
https://pillow.readthedocs.io/en/stable/reference/Image.html

### Changes proposed in this PR

- [x] Tests added/updated - N/A
- [X] Documentation updated
- [X] Changelog entry added
- [X] `./check.sh` passed
