### PR TITLE
Revert "build(deps-dev): bump build from 1.5.0 to 1.5.1"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ mss = "mss.__main__:main"
 
 [project.optional-dependencies]
 dev = [
-  "build==1.5.1",
+  "build==1.5.0",
   "lxml==6.1.1",
   "mypy==2.3.0",
   "ruff==0.15.22",


### PR DESCRIPTION
This reverts commit 753608b8eb227d68016c9cb642e6d307413f28e6.

Version 1.5.1 has since been yanked; see https://pypi.org/project/build/1.5.1/

This isn't causing any issues at the moment, but it seems like we should probably not use it anyway.  Future versions of other build tools might depend on the behavior that's changed.

### Changes proposed in this PR

- [ ] Tests added/updated - N/A
- [ ] Documentation updated - N/A
- [ ] Changelog entry added - N/A
- [X] `./check.sh` passed

### AI assistance disclosure

- [X] No AI assistance was used to generate this contribution.
