### PR TITLE
Add immutable Monitor model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,11 +43,12 @@ Run tests:
 python -m pytest
 ```
 
-When adding, removing, or renaming a file included in the source distribution, update the explicit expected file list
-in `src/tests/test_setup.py::test_sdist` and run the focused packaging test:
+When adding, removing, or renaming a packaged file, update the explicit expected file list in
+`src/tests/test_setup.py::test_sdist` and, for files included in binary distributions, in
+`src/tests/test_setup.py::test_wheel`. Run the focused packaging tests:
 
 ```shell
-python -m pytest src/tests/test_setup.py::test_sdist
+python -m pytest src/tests/test_setup.py::test_sdist src/tests/test_setup.py::test_wheel
 ```
 
 On headless GNU/Linux environments, run tests with a virtual display:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,13 @@ Run tests:
 python -m pytest
 ```
 
+When adding, removing, or renaming a file included in the source distribution, update the explicit expected file list
+in `src/tests/test_setup.py::test_sdist` and run the focused packaging test:
+
+```shell
+python -m pytest src/tests/test_setup.py::test_sdist
+```
+
 On headless GNU/Linux environments, run tests with a virtual display:
 
 ```shell

--- a/demos/cat-detector.py
+++ b/demos/cat-detector.py
@@ -224,7 +224,7 @@ def main() -> None:
         monitor = sct.monitors[1]
 
         # Compute the minimum size, in square pixels, that we'll consider reliable.
-        img_area = monitor["width"] * monitor["height"]
+        img_area = monitor.width * monitor.height
         min_box_area = MIN_AREA_FRAC * img_area
 
         # We start a new line of the log if the cat visibility status changes.  That way, your terminal will show

--- a/demos/tinytv-stream.py
+++ b/demos/tinytv-stream.py
@@ -148,6 +148,7 @@ from prettytable import PrettyTable, TableStyle
 from serial.tools import list_ports
 
 import mss
+from mss.models import Region
 
 from common.pipeline import Mailbox, PipelineStage
 
@@ -330,7 +331,7 @@ def _scale_stretch(img: Image.Image, size: tuple[int, int]) -> Image.Image:
 def capture_image(
     *,
     monitor: int | None = None,
-    capture_area: dict[str, int] | None = None,
+    capture_area: Region | None = None,
 ) -> Generator[Image.Image]:
     """Continuously capture images from the specified monitor.
 
@@ -338,13 +339,12 @@ def capture_image(
 
     :param monitor: Monitor number to capture from, using the standard
         MSS convention (all screens=0, first screen=1, etc.).
-    :param capture_area: Capture rectangle dict with 'left', 'top',
-        'width', 'height'.
+    :param capture_area: Capture region.
     :yields: PIL Image objects from the captured monitor.
     """
     with mss.MSS() as sct:
         rect = capture_area if capture_area is not None else sct.monitors[monitor]
-        LOGGER.debug("Capture area: %i,%i, %ix%i", rect["left"], rect["top"], rect["width"], rect["height"])
+        LOGGER.debug("Capture area: %i,%i, %ix%i", rect.left, rect.top, rect.width, rect.height)
 
         while True:
             sct_img = sct.grab(rect)
@@ -510,14 +510,14 @@ def _quality_type(value: str) -> int:
     raise argparse.ArgumentTypeError(msg)
 
 
-def _capture_area_type(value: str) -> dict[str, int]:
-    """Validate and return a capture area dict.
+def _capture_area_type(value: str) -> Region:
+    """Validate and return a capture region.
 
     Expected format is ``left,top,width,height`` where all values are
     integers.
 
     :param value: The capture area string to validate.
-    :returns: Dict with 'left', 'top', 'width', 'height' keys.
+    :returns: Capture region.
     :raises argparse.ArgumentTypeError: If the format is invalid or extents
         are non-positive.
     """
@@ -536,7 +536,7 @@ def _capture_area_type(value: str) -> dict[str, int]:
         msg = "Capture area width and height must be positive"
         raise argparse.ArgumentTypeError(msg)
 
-    return {"left": left, "top": top, "width": width, "height": height}
+    return Region(left=left, top=top, width=width, height=height)
 
 
 def main() -> None:

--- a/demos/video-capture-simple.py
+++ b/demos/video-capture-simple.py
@@ -72,17 +72,21 @@ def main() -> None:
         monitor = sct.monitors[1]
 
         # Because of how H.264 video stores color information, libx264 requires the video size to be a multiple of
-        # two.
-        monitor["width"] = (monitor["width"] // 2) * 2
-        monitor["height"] = (monitor["height"] // 2) * 2
+        # two.  Keep the monitor description unchanged and capture a slightly smaller region when necessary.
+        capture_region = {
+            "left": monitor.left,
+            "top": monitor.top,
+            "width": (monitor.width // 2) * 2,
+            "height": (monitor.height // 2) * 2,
+        }
 
         with av.open(FILENAME, "w") as avmux:
             # The "avmux" object we get back from "av.open" represents the MP4 file.  That's a container that holds
             # the video, as well as possibly audio and more.  These are each called "streams".  We only create one
             # stream here, since we're just recording video.
             video_stream = avmux.add_stream(CODEC, rate=FPS, options=CODEC_OPTIONS)
-            video_stream.width = monitor["width"]
-            video_stream.height = monitor["height"]
+            video_stream.width = capture_region["width"]
+            video_stream.height = capture_region["height"]
             # There are more options you can set on the video stream; the full demo uses some of those.
 
             # Count how many frames we're capturing, so we can log the FPS later.
@@ -121,7 +125,7 @@ def main() -> None:
                 print(".", end="", flush=True)
 
                 # Grab a screenshot.
-                screenshot = sct.grab(monitor)
+                screenshot = sct.grab(capture_region)
                 frame_count += 1
 
                 # There are a few ways to get the screenshot into a VideoFrame.  The highest-performance way isn't

--- a/demos/video-capture-simple.py
+++ b/demos/video-capture-simple.py
@@ -35,6 +35,7 @@ import av
 from PIL import Image
 
 import mss
+from mss.models import Region
 
 # These are the options you'd give to ffmpeg that would affect the way the video is encoded.  There are comments in
 # the full demo that go into more detail.
@@ -73,20 +74,20 @@ def main() -> None:
 
         # Because of how H.264 video stores color information, libx264 requires the video size to be a multiple of
         # two.  Keep the monitor description unchanged and capture a slightly smaller region when necessary.
-        capture_region = {
-            "left": monitor.left,
-            "top": monitor.top,
-            "width": (monitor.width // 2) * 2,
-            "height": (monitor.height // 2) * 2,
-        }
+        capture_region = Region(
+            left=monitor.left,
+            top=monitor.top,
+            width=(monitor.width // 2) * 2,
+            height=(monitor.height // 2) * 2,
+        )
 
         with av.open(FILENAME, "w") as avmux:
             # The "avmux" object we get back from "av.open" represents the MP4 file.  That's a container that holds
             # the video, as well as possibly audio and more.  These are each called "streams".  We only create one
             # stream here, since we're just recording video.
             video_stream = avmux.add_stream(CODEC, rate=FPS, options=CODEC_OPTIONS)
-            video_stream.width = capture_region["width"]
-            video_stream.height = capture_region["height"]
+            video_stream.width = capture_region.width
+            video_stream.height = capture_region.height
             # There are more options you can set on the video stream; the full demo uses some of those.
 
             # Count how many frames we're capturing, so we can log the FPS later.

--- a/demos/video-capture.py
+++ b/demos/video-capture.py
@@ -126,6 +126,7 @@ import av
 from si_prefix import si_format
 
 import mss
+from mss.models import Region
 
 from common.pipeline import Mailbox, PipelineStage
 
@@ -165,7 +166,7 @@ LOGGER = logging.getLogger("video-capture")
 def video_capture(
     fps: int,
     sct: mss.MSS,
-    capture_region: dict[str, int],
+    capture_region: Region,
     shutdown_requested: Event,
 ) -> Generator[tuple[mss.screenshot.ScreenShot, float], None, None]:
     # Keep track of the time when we want to get the next frame.  We limit the frame time this way instead of sleeping
@@ -436,12 +437,7 @@ def main() -> None:
     with mss.MSS() as sct:
         if args.region:
             left, top, right, bottom = args.region
-            capture_region = {
-                "left": left,
-                "top": top,
-                "width": right - left,
-                "height": bottom - top,
-            }
+            capture_region = Region(left=left, top=top, width=right - left, height=bottom - top)
         else:
             monitor = sct.monitors[args.monitor]
             capture_region = monitor.as_region()
@@ -454,8 +450,8 @@ def main() -> None:
             # it (at least, when using 4:2:0 subsampling).
             region_crop_to_multiple_of_two = codec in {"libx264", "libx265"}
         if region_crop_to_multiple_of_two:
-            capture_region["width"] = (capture_region["width"] // 2) * 2
-            capture_region["height"] = (capture_region["height"] // 2) * 2
+            capture_region.width = (capture_region.width // 2) * 2
+            capture_region.height = (capture_region.height // 2) * 2
 
         # We don't pass the container format to av.open here, so it will choose it based on the extension: .mp4, .mkv,
         # etc.
@@ -494,8 +490,8 @@ def main() -> None:
                 # so some video encoders will tag it as AVCOL_TRC_BT709 (1) instead.
                 video_stream.color_trc = 13
 
-            video_stream.width = capture_region["width"]
-            video_stream.height = capture_region["height"]
+            video_stream.width = capture_region.width
+            video_stream.height = capture_region.height
             # There are multiple time bases in play (stream, codec context, per-frame).  Depending on the container
             # and codec, some of these might be ignored or overridden.  We set the desired time base consistently
             # everywhere, so that the saved timestamps are correct regardless of what format we're saving to.

--- a/demos/video-capture.py
+++ b/demos/video-capture.py
@@ -122,12 +122,10 @@ from typing import Any
 
 # Install the necessary libraries with "pip install av mss numpy si-prefix".
 import av
-import numpy as np
+from common.pipeline import Mailbox, PipelineStage
 from si_prefix import si_format
 
 import mss
-from common.pipeline import Mailbox, PipelineStage
-
 
 # These are the options you'd give to ffmpeg that it sends to the video codec.  Because ffmpeg and PyAV both use the
 # libav libraries, you can get the list of available flags with `ffmpeg -help encoder=libx264`, or whatever encoder
@@ -165,7 +163,7 @@ LOGGER = logging.getLogger("video-capture")
 def video_capture(
     fps: int,
     sct: mss.MSS,
-    monitor: mss.models.Monitor,
+    capture_region: dict[str, int],
     shutdown_requested: Event,
 ) -> Generator[tuple[mss.screenshot.ScreenShot, float], None, None]:
     # Keep track of the time when we want to get the next frame.  We limit the frame time this way instead of sleeping
@@ -183,7 +181,7 @@ def video_capture(
             time.sleep(next_frame_at - now)
 
         # Capture a frame, and send it to the next processing stage.
-        screenshot = sct.grab(monitor)
+        screenshot = sct.grab(capture_region)
         yield screenshot, now
 
         # We try to keep the capture rate at the desired fps on average.  If we can't quite keep up for a moment (such
@@ -436,7 +434,7 @@ def main() -> None:
     with mss.MSS() as sct:
         if args.region:
             left, top, right, bottom = args.region
-            monitor = {
+            capture_region = {
                 "left": left,
                 "top": top,
                 "width": right - left,
@@ -444,6 +442,12 @@ def main() -> None:
             }
         else:
             monitor = sct.monitors[args.monitor]
+            capture_region = {
+                "left": monitor.left,
+                "top": monitor.top,
+                "width": monitor.width,
+                "height": monitor.height,
+            }
 
         # Some codecs, such as libx264, require the region to be a multiple of 2, to get the chroma subsampling right.
         # Others, such as h264_nvenc, do not; they'll pad to get the subsampling region, and add flags to the stream
@@ -453,8 +457,8 @@ def main() -> None:
             # it (at least, when using 4:2:0 subsampling).
             region_crop_to_multiple_of_two = codec in {"libx264", "libx265"}
         if region_crop_to_multiple_of_two:
-            monitor["width"] = (monitor["width"] // 2) * 2
-            monitor["height"] = (monitor["height"] // 2) * 2
+            capture_region["width"] = (capture_region["width"] // 2) * 2
+            capture_region["height"] = (capture_region["height"] // 2) * 2
 
         # We don't pass the container format to av.open here, so it will choose it based on the extension: .mp4, .mkv,
         # etc.
@@ -493,8 +497,8 @@ def main() -> None:
                 # so some video encoders will tag it as AVCOL_TRC_BT709 (1) instead.
                 video_stream.color_trc = 13
 
-            video_stream.width = monitor["width"]
-            video_stream.height = monitor["height"]
+            video_stream.width = capture_region["width"]
+            video_stream.height = capture_region["height"]
             # There are multiple time bases in play (stream, codec context, per-frame).  Depending on the container
             # and codec, some of these might be ignored or overridden.  We set the desired time base consistently
             # everywhere, so that the saved timestamps are correct regardless of what format we're saving to.
@@ -535,7 +539,7 @@ def main() -> None:
                     video_capture,
                     fps,
                     sct,
-                    monitor,
+                    capture_region,
                     shutdown_requested,
                 ),
                 out_mailbox=mailbox_screenshot,

--- a/demos/video-capture.py
+++ b/demos/video-capture.py
@@ -121,6 +121,7 @@ from threading import Event
 from typing import Any
 
 # Install the necessary libraries with "pip install av mss numpy si-prefix".
+# Note that numpy is needed even if we don't explicitly import it here.
 import av
 from si_prefix import si_format
 

--- a/demos/video-capture.py
+++ b/demos/video-capture.py
@@ -122,10 +122,11 @@ from typing import Any
 
 # Install the necessary libraries with "pip install av mss numpy si-prefix".
 import av
-from common.pipeline import Mailbox, PipelineStage
 from si_prefix import si_format
 
 import mss
+
+from common.pipeline import Mailbox, PipelineStage
 
 # These are the options you'd give to ffmpeg that it sends to the video codec.  Because ffmpeg and PyAV both use the
 # libav libraries, you can get the list of available flags with `ffmpeg -help encoder=libx264`, or whatever encoder
@@ -442,12 +443,7 @@ def main() -> None:
             }
         else:
             monitor = sct.monitors[args.monitor]
-            capture_region = {
-                "left": monitor.left,
-                "top": monitor.top,
-                "width": monitor.width,
-                "height": monitor.height,
-            }
+            capture_region = monitor.as_capture_region()
 
         # Some codecs, such as libx264, require the region to be a multiple of 2, to get the chroma subsampling right.
         # Others, such as h264_nvenc, do not; they'll pad to get the subsampling region, and add flags to the stream

--- a/demos/video-capture.py
+++ b/demos/video-capture.py
@@ -444,7 +444,7 @@ def main() -> None:
             }
         else:
             monitor = sct.monitors[args.monitor]
-            capture_region = monitor.as_capture_region()
+            capture_region = monitor.as_region()
 
         # Some codecs, such as libx264, require the region to be a multiple of 2, to get the chroma subsampling right.
         # Others, such as h264_nvenc, do not; they'll pad to get the subsampling region, and add flags to the stream

--- a/docs/source/examples/custom_cls_image.py
+++ b/docs/source/examples/custom_cls_image.py
@@ -7,7 +7,7 @@ Screenshot of the monitor 1, using a custom class to handle the data.
 from typing import Any
 
 import mss
-from mss.models import Monitor
+from mss.models import CaptureRegion
 from mss.screenshot import ScreenShot
 
 
@@ -17,9 +17,9 @@ class SimpleScreenShot(ScreenShot):
     or add new methods.
     """
 
-    def __init__(self, data: bytearray, monitor: Monitor, **_: Any) -> None:
+    def __init__(self, data: bytearray, region: CaptureRegion, **_: Any) -> None:
         self.data = data
-        self.monitor = monitor
+        self.region = region
 
 
 with mss.MSS() as sct:

--- a/docs/source/examples/custom_cls_image.py
+++ b/docs/source/examples/custom_cls_image.py
@@ -7,7 +7,7 @@ Screenshot of the monitor 1, using a custom class to handle the data.
 from typing import Any
 
 import mss
-from mss.models import CaptureRegion
+from mss.models import Region
 from mss.screenshot import ScreenShot
 
 
@@ -17,7 +17,7 @@ class SimpleScreenShot(ScreenShot):
     or add new methods.
     """
 
-    def __init__(self, data: bytearray, region: CaptureRegion, **_: Any) -> None:
+    def __init__(self, data: bytearray, region: Region, **_: Any) -> None:
         self.data = data
         self.region = region
 

--- a/docs/source/examples/fps.py
+++ b/docs/source/examples/fps.py
@@ -12,6 +12,7 @@ import numpy as np
 from PIL import ImageGrab
 
 import mss
+from mss.models import Region
 
 
 def screen_record() -> int:
@@ -36,7 +37,7 @@ def screen_record() -> int:
 
 def screen_record_efficient() -> int:
     # 800x600 windowed mode
-    mon = {"top": 40, "left": 0, "width": 800, "height": 640}
+    region = Region(left=0, top=40, width=800, height=640)
 
     title = "[MSS] FPS benchmark"
     fps = 0
@@ -44,7 +45,7 @@ def screen_record_efficient() -> int:
     last_time = time.time()
 
     while time.time() - last_time < 1:
-        img = np.asarray(sct.grab(mon))
+        img = np.asarray(sct.grab(region))
         fps += 1
 
         cv2.imshow(title, img)

--- a/docs/source/examples/fps_multiprocessing.py
+++ b/docs/source/examples/fps_multiprocessing.py
@@ -9,14 +9,15 @@ from multiprocessing import Process, Queue
 
 import mss
 import mss.tools
+from mss.models import Region
 
 
 def grab(queue: Queue) -> None:
-    rect = {"top": 0, "left": 0, "width": 600, "height": 800}
+    region = Region(left=0, top=0, width=600, height=800)
 
     with mss.MSS() as sct:
         for _ in range(1_000):
-            queue.put(sct.grab(rect))
+            queue.put(sct.grab(region))
 
     # Tell the other worker to stop
     queue.put(None)

--- a/docs/source/examples/from_pil_tuple.py
+++ b/docs/source/examples/from_pil_tuple.py
@@ -12,8 +12,8 @@ with mss.MSS() as sct:
     monitor = sct.monitors[1]
 
     # Capture a bbox using percent values
-    left = monitor["left"] + monitor["width"] * 5 // 100  # 5% from the left
-    top = monitor["top"] + monitor["height"] * 5 // 100  # 5% from the top
+    left = monitor.left + monitor.width * 5 // 100  # 5% from the left
+    top = monitor.top + monitor.height * 5 // 100  # 5% from the top
     right = left + 400  # 400px width
     lower = top + 400  # 400px height
     bbox = (left, top, right, lower)

--- a/docs/source/examples/opencv_numpy.py
+++ b/docs/source/examples/opencv_numpy.py
@@ -9,17 +9,18 @@ import time
 import cv2
 
 import mss
+from mss.models import Region
 
 with mss.MSS() as sct:
     # Part of the screen to capture
-    monitor = {"top": 40, "left": 0, "width": 800, "height": 640}
+    region = Region(left=0, top=40, width=800, height=640)
 
     while "Screen capturing":
         last_time = time.time()
 
         # Get raw pixels from the screen, save it to a NumPy array.
         # Note that OpenCV expects colors in BGR order.
-        img = sct.grab(monitor).to_numpy(channels="BGR")
+        img = sct.grab(region).to_numpy(channels="BGR")
 
         # Display the picture
         cv2.imshow("OpenCV/NumPy normal", img)

--- a/docs/source/examples/part_of_screen.py
+++ b/docs/source/examples/part_of_screen.py
@@ -6,14 +6,15 @@ Example to capture part of the screen.
 
 import mss
 import mss.tools
+from mss.models import Region
 
 with mss.MSS() as sct:
     # The screen part to capture
-    monitor = {"top": 160, "left": 160, "width": 160, "height": 135}
-    output = "sct-{top}x{left}_{width}x{height}.png".format(**monitor)
+    region = Region(left=160, top=160, width=160, height=135)
+    output = f"sct-{region.top}x{region.left}_{region.width}x{region.height}.png"
 
     # Grab the data
-    sct_img = sct.grab(monitor)
+    sct_img = sct.grab(region)
 
     # Save to the picture file
     mss.tools.to_png(sct_img.rgb, sct_img.size, output=output)

--- a/docs/source/examples/part_of_screen_monitor_2.py
+++ b/docs/source/examples/part_of_screen_monitor_2.py
@@ -6,24 +6,24 @@ Example to capture part of the screen of the monitor 2.
 
 import mss
 import mss.tools
+from mss.models import Region
 
 with mss.MSS() as sct:
     # Get information of monitor 2
     monitor_number = 2
-    mon = sct.monitors[monitor_number]
+    monitor = sct.monitors[monitor_number]
 
     # The screen part to capture
-    monitor = {
-        "top": mon.top + 100,  # 100px from the top
-        "left": mon.left + 100,  # 100px from the left
-        "width": 160,
-        "height": 135,
-        "mon": monitor_number,
-    }
-    output = "sct-mon{mon}_{top}x{left}_{width}x{height}.png".format(**monitor)
+    region = Region(
+        left=monitor.left + 100,  # 100px from the left
+        top=monitor.top + 100,  # 100px from the top
+        width=160,
+        height=135,
+    )
+    output = f"sct-mon{monitor_number}_{region.top}x{region.left}_{region.width}x{region.height}.png"
 
     # Grab the data
-    sct_img = sct.grab(monitor)
+    sct_img = sct.grab(region)
 
     # Save to the picture file
     mss.tools.to_png(sct_img.rgb, sct_img.size, output=output)

--- a/docs/source/examples/part_of_screen_monitor_2.py
+++ b/docs/source/examples/part_of_screen_monitor_2.py
@@ -14,8 +14,8 @@ with mss.MSS() as sct:
 
     # The screen part to capture
     monitor = {
-        "top": mon["top"] + 100,  # 100px from the top
-        "left": mon["left"] + 100,  # 100px from the left
+        "top": mon.top + 100,  # 100px from the top
+        "left": mon.left + 100,  # 100px from the left
         "width": 160,
         "height": 135,
         "mon": monitor_number,

--- a/docs/source/release-history/v10.2.0.md
+++ b/docs/source/release-history/v10.2.0.md
@@ -260,7 +260,7 @@ In 11.0, monitor dictionaries will become a dedicated **`Monitor` class**.
 
 To maintain compatibility:
 
-- dictionary-style access will continue to work
+- string-key access will temporarily continue to work
 
 ```python
 monitor["left"]
@@ -268,6 +268,14 @@ monitor["top"]
 ```
 
 - `grab()` will continue accepting dictionaries
+
+The compatibility access does not make `Monitor` a complete mapping.  Migrate dictionary methods, membership tests, and
+unpacking to attribute access:
+
+```python
+monitor.left
+monitor.top
+```
 
 If you use type annotations, you can switch to the provided `Monitor` type:
 

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -35,15 +35,17 @@ monitor = sct.monitors[1]
 print(monitor.left, monitor.top, monitor.width, monitor.height)
 print(monitor.is_primary, monitor.name, monitor.unique_id, monitor.output)
 region = monitor.as_region()
+region.width -= 1
 ```
 
 The four geometry attributes are always present.  Metadata attributes are `None` when unavailable.  String-key access
 such as `monitor["width"]` remains temporarily available for migration, but `Monitor` is not a mapping: dictionary
 methods, membership tests, and `**monitor` unpacking are not supported.
-Use {py:meth}`mss.models.Monitor.as_region` when a mutable capture-region dictionary is needed.
+Use {py:meth}`mss.models.Monitor.as_region` to create a {py:class}`mss.models.Region` matching the monitor geometry. Region geometry is
+available through the same `left`, `top`, `width`, and `height` attributes.
 
-Existing regions can still be passed to {py:meth}`mss.MSS.grab` as dictionaries or PIL-style
-`(left, top, right, bottom)` tuples.
+Capture regions can still be passed to {py:meth}`mss.MSS.grab` as dictionaries or PIL-style `(left, top, right, bottom)`
+tuples; they are converted to {py:class}`mss.models.Region` objects internally.
 
 ### Python 3.9 EOL
 

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -22,6 +22,24 @@ The {py:attr}`mss.ScreenShot.bgra` and {py:attr}`mss.ScreenShot.rgb` properties 
 {py:class}`memoryview` objects, rather than {py:class}`bytes` or {py:class}`bytearray` objects.  For practical use
 cases, this should not be noticeable.  This change allows faster access to screenshot data, with fewer memory copies.
 
+#### Immutable monitor objects
+
+{py:attr}`mss.MSS.monitors` now returns frozen, slotted {py:class}`mss.models.Monitor` objects instead of dictionaries.
+Use attributes for geometry and metadata:
+
+```python
+monitor = sct.monitors[1]
+print(monitor.left, monitor.top, monitor.width, monitor.height)
+print(monitor.is_primary, monitor.name, monitor.unique_id, monitor.output)
+```
+
+The four geometry attributes are always present.  Metadata attributes are `None` when unavailable.  String-key access
+such as `monitor["width"]` remains temporarily available for migration, but `Monitor` is not a mapping: dictionary
+methods, membership tests, and `**monitor` unpacking are not supported.
+
+Existing regions can still be passed to {py:meth}`mss.MSS.grab` as dictionaries or PIL-style
+`(left, top, right, bottom)` tuples.
+
 ### Python 3.9 EOL
 
 Python 3.9 reached [end-of-life](https://devguide.python.org/developer-workflow/development-cycle/index.html#end-of-life-branches) on [October 31, 2025](https://devguide.python.org/versions/).  It is no longer receiving any updates, even security updates.

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -25,17 +25,21 @@ cases, this should not be noticeable.  This change allows faster access to scree
 #### Immutable monitor objects
 
 {py:attr}`mss.MSS.monitors` now returns frozen, slotted {py:class}`mss.models.Monitor` objects instead of dictionaries.
+Monitor entries are cached display-configuration snapshots; keeping them immutable prevents application code from
+accidentally changing the geometry or metadata held by an {py:class}`mss.MSS` instance.
 Use attributes for geometry and metadata:
 
 ```python
 monitor = sct.monitors[1]
 print(monitor.left, monitor.top, monitor.width, monitor.height)
 print(monitor.is_primary, monitor.name, monitor.unique_id, monitor.output)
+region = monitor.as_capture_region()
 ```
 
 The four geometry attributes are always present.  Metadata attributes are `None` when unavailable.  String-key access
 such as `monitor["width"]` remains temporarily available for migration, but `Monitor` is not a mapping: dictionary
 methods, membership tests, and `**monitor` unpacking are not supported.
+Use {py:meth}`mss.models.Monitor.as_capture_region` when a mutable capture-region dictionary is needed.
 
 Existing regions can still be passed to {py:meth}`mss.MSS.grab` as dictionaries or PIL-style
 `(left, top, right, bottom)` tuples.

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -34,13 +34,13 @@ application code from accidentally changing the geometry or metadata held by an
 monitor = sct.monitors[1]
 print(monitor.left, monitor.top, monitor.width, monitor.height)
 print(monitor.is_primary, monitor.name, monitor.unique_id, monitor.output)
-region = monitor.as_capture_region()
+region = monitor.as_region()
 ```
 
 The four geometry attributes are always present.  Metadata attributes are `None` when unavailable.  String-key access
 such as `monitor["width"]` remains temporarily available for migration, but `Monitor` is not a mapping: dictionary
 methods, membership tests, and `**monitor` unpacking are not supported.
-Use {py:meth}`mss.models.Monitor.as_capture_region` when a mutable capture-region dictionary is needed.
+Use {py:meth}`mss.models.Monitor.as_region` when a mutable capture-region dictionary is needed.
 
 Existing regions can still be passed to {py:meth}`mss.MSS.grab` as dictionaries or PIL-style
 `(left, top, right, bottom)` tuples.

--- a/docs/source/release-history/v11.0.0.md
+++ b/docs/source/release-history/v11.0.0.md
@@ -24,10 +24,11 @@ cases, this should not be noticeable.  This change allows faster access to scree
 
 #### Immutable monitor objects
 
-{py:attr}`mss.MSS.monitors` now returns frozen, slotted {py:class}`mss.models.Monitor` objects instead of dictionaries.
-Monitor entries are cached display-configuration snapshots; keeping them immutable prevents application code from
-accidentally changing the geometry or metadata held by an {py:class}`mss.MSS` instance.
-Use attributes for geometry and metadata:
+{py:attr}`mss.MSS.monitors` now returns immutable {py:class}`mss.models.Monitor`
+objects instead of dictionaries. Monitor entries are cached
+display-configuration snapshots; making them frozen and slotted prevents
+application code from accidentally changing the geometry or metadata held by an
+{py:class}`mss.MSS` instance. Use attributes to read geometry and metadata:
 
 ```python
 monitor = sct.monitors[1]

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -59,15 +59,18 @@ are ``None`` when unavailable::
     monitor = sct.monitors[1]
     print(monitor.width, monitor.height)
 
-Call ``monitor.as_region()`` when you need its geometry as a mutable capture-region dictionary.
+Call ``monitor.as_region()`` when you need its geometry as a :py:class:`mss.models.Region`::
+
+    region = monitor.as_region()
+    region.width -= 1
+    screenshot = sct.grab(region)
 
 For migration from MSS 10, string-key access such as ``monitor["width"]`` is temporarily supported.  ``Monitor`` is not
 a mapping, so dictionary methods, membership tests, and ``**monitor`` unpacking are not supported.  New code should use
 attributes.
 
-For capturing a specific region, you can pass :py:meth:`mss.MSS.grab` a dictionary with the keys ``top``, ``left``,
-``width``, and ``height``.  For instance, to capture a 100x100 pixel region starting at the top-left corner of the
-screen, you could use :python:`{"top": 0, "left": 0, "width": 100, "height": 100}`.  You can also use a PIL-style box,
+For capturing a specific region, construct a mutable :py:class:`mss.models.Region` with ``top``, ``left``, ``width``,
+and ``height`` attributes.  You can also pass :py:meth:`mss.MSS.grab` a dictionary with those keys or a PIL-style box,
 which is a 4-tuple of ``(left, top, right, bottom)``.
 
 Once you've decided what you want to capture, you can call :py:meth:`mss.MSS.grab` with the appropriate monitor or

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -59,6 +59,8 @@ are ``None`` when unavailable::
     monitor = sct.monitors[1]
     print(monitor.width, monitor.height)
 
+Call ``monitor.as_capture_region()`` when you need its geometry as a mutable capture-region dictionary.
+
 For migration from MSS 10, string-key access such as ``monitor["width"]`` is temporarily supported.  ``Monitor`` is not
 a mapping, so dictionary methods, membership tests, and ``**monitor`` unpacking are not supported.  New code should use
 attributes.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -52,6 +52,17 @@ list of all the monitors, starting from index 1, as well as the full virtual scr
 The primary monitor, the one that holds the taskbar or similar system UI, is available as
 :py:attr:`mss.MSS.primary_monitor`.
 
+Each entry is an immutable :py:class:`mss.models.Monitor`.  Its geometry is available through ``left``, ``top``,
+``width``, and ``height`` attributes.  The ``is_primary``, ``name``, ``unique_id``, and ``output`` metadata attributes
+are ``None`` when unavailable::
+
+    monitor = sct.monitors[1]
+    print(monitor.width, monitor.height)
+
+For migration from MSS 10, string-key access such as ``monitor["width"]`` is temporarily supported.  ``Monitor`` is not
+a mapping, so dictionary methods, membership tests, and ``**monitor`` unpacking are not supported.  New code should use
+attributes.
+
 For capturing a specific region, you can pass :py:meth:`mss.MSS.grab` a dictionary with the keys ``top``, ``left``,
 ``width``, and ``height``.  For instance, to capture a 100x100 pixel region starting at the top-left corner of the
 screen, you could use :python:`{"top": 0, "left": 0, "width": 100, "height": 100}`.  You can also use a PIL-style box,

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -59,7 +59,7 @@ are ``None`` when unavailable::
     monitor = sct.monitors[1]
     print(monitor.width, monitor.height)
 
-Call ``monitor.as_capture_region()`` when you need its geometry as a mutable capture-region dictionary.
+Call ``monitor.as_region()`` when you need its geometry as a mutable capture-region dictionary.
 
 For migration from MSS 10, string-key access such as ``monitor["width"]`` is temporarily supported.  ``Monitor`` is not
 a mapping, so dictionary methods, membership tests, and ``**monitor`` unpacking are not supported.  New code should use

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -70,8 +70,12 @@ a mapping, so dictionary methods, membership tests, and ``**monitor`` unpacking 
 attributes.
 
 For capturing a specific region, construct a mutable :py:class:`mss.models.Region` with ``top``, ``left``, ``width``,
-and ``height`` attributes.  You can also pass :py:meth:`mss.MSS.grab` a dictionary with those keys or a PIL-style box,
-which is a 4-tuple of ``(left, top, right, bottom)``.
+and ``height`` attributes.  Region dictionaries remain supported for compatibility::
+
+    screenshot = sct.grab({"top": 0, "left": 0, "width": 100, "height": 100})
+
+You can also pass :py:meth:`mss.MSS.grab` a PIL-style box, which is a 4-tuple of
+``(left, top, right, bottom)``.
 
 Once you've decided what you want to capture, you can call :py:meth:`mss.MSS.grab` with the appropriate monitor or
 region.  This will return a :py:class:`mss.ScreenShot` object, which contains the pixel data and other information about

--- a/src/mss/__main__.py
+++ b/src/mss/__main__.py
@@ -155,9 +155,9 @@ def _capture_and_save(
     """Capture screenshots and write output files."""
     if coordinates is not None:
         if coordinates["top"] < 0:
-            coordinates["top"] = sct.monitors[monitor_index]["height"] + coordinates["top"]
+            coordinates["top"] = sct.monitors[monitor_index].height + coordinates["top"]
         if coordinates["left"] < 0:
-            coordinates["left"] = sct.monitors[monitor_index]["width"] + coordinates["left"]
+            coordinates["left"] = sct.monitors[monitor_index].width + coordinates["left"]
         output = output_template.format(**coordinates)
         sct_img = sct.grab(coordinates)
         to_png(sct_img.rgb, sct_img.size, level=options.level, output=output)

--- a/src/mss/__main__.py
+++ b/src/mss/__main__.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from mss import MSS, __version__
 from mss.exception import ScreenShotError
+from mss.models import Region
 from mss.tools import to_png
 
 _COORDINATES_SYNTAX = "TOP,LEFT,WIDTH,HEIGHT or WIDTHxHEIGHT+LEFT+TOP"
@@ -117,7 +118,7 @@ def _build_parser() -> ArgumentParser:
     return cli_args
 
 
-def _prepare_grab_options(options: Namespace) -> tuple[int, str, dict[str, int] | None]:
+def _prepare_grab_options(options: Namespace) -> tuple[int, str, Region | None]:
     """Build grab options derived from parsed CLI arguments."""
     monitor_index = int(options.monitor)
     output_template = str(options.output)
@@ -125,12 +126,7 @@ def _prepare_grab_options(options: Namespace) -> tuple[int, str, dict[str, int] 
         return monitor_index, output_template, None
 
     top, left, width, height = _parse_coordinates(str(options.coordinates))
-    coordinates = {
-        "top": int(top),
-        "left": int(left),
-        "width": int(width),
-        "height": int(height),
-    }
+    coordinates = Region(top=int(top), left=int(left), width=int(width), height=int(height))
     if options.output == "monitor-{mon}.png":
         output_template = "sct-{top}x{left}_{width}x{height}.png"
     return monitor_index, output_template, coordinates
@@ -150,15 +146,20 @@ def _capture_and_save(
     options: Namespace,
     monitor_index: int,
     output_template: str,
-    coordinates: dict[str, int] | None,
+    coordinates: Region | None,
 ) -> None:
     """Capture screenshots and write output files."""
     if coordinates is not None:
-        if coordinates["top"] < 0:
-            coordinates["top"] = sct.monitors[monitor_index].height + coordinates["top"]
-        if coordinates["left"] < 0:
-            coordinates["left"] = sct.monitors[monitor_index].width + coordinates["left"]
-        output = output_template.format(**coordinates)
+        if coordinates.top < 0:
+            coordinates.top = sct.monitors[monitor_index].height + coordinates.top
+        if coordinates.left < 0:
+            coordinates.left = sct.monitors[monitor_index].width + coordinates.left
+        output = output_template.format(
+            top=coordinates.top,
+            left=coordinates.left,
+            width=coordinates.width,
+            height=coordinates.height,
+        )
         sct_img = sct.grab(coordinates)
         to_png(sct_img.rgb, sct_img.size, level=options.level, output=output)
         if not options.quiet:

--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Buffer, Self
 
-    from mss.models import Monitors, Size
+    from mss.models import CaptureRegion, Monitors, Size
 
 try:
     from datetime import UTC
@@ -90,11 +90,14 @@ class MSSImplementation(ABC):
         """Retrieve all cursor data. Pixels have to be RGB."""
 
     @abstractmethod
-    def grab(self, monitor: Monitor, /) -> Buffer | tuple[Buffer, Size]:
-        """Retrieve all pixels from a monitor. Pixels have to be RGB.
+    def grab(self, region: CaptureRegion, /) -> Buffer | tuple[Buffer, Size]:
+        """Retrieve all pixels from a capture region. Pixels have to be RGB.
 
-        If the monitor size is not in pixel units, include a Size in
-        pixels (see issue #23).
+        Return ``(buffer, size)`` when the pixel dimensions of the returned
+        buffer differ from the region's width and height. For example, a
+        Retina display region may be measured in logical points while its
+        image buffer contains twice as many pixels in each dimension (see
+        issue #23).
         """
 
     @abstractmethod
@@ -304,36 +307,34 @@ class MSS:
         """
         # Convert PIL bbox style
         if isinstance(monitor, tuple):
-            monitor = Monitor(
-                left=monitor[0],
-                top=monitor[1],
-                width=monitor[2] - monitor[0],
-                height=monitor[3] - monitor[1],
-            )
+            region: CaptureRegion = {
+                "left": monitor[0],
+                "top": monitor[1],
+                "width": monitor[2] - monitor[0],
+                "height": monitor[3] - monitor[1],
+            }
+        elif isinstance(monitor, Monitor):
+            region = monitor.as_capture_region()
         elif isinstance(monitor, dict):
-            monitor = Monitor(
-                left=monitor["left"],
-                top=monitor["top"],
-                width=monitor["width"],
-                height=monitor["height"],
-                is_primary=monitor.get("is_primary"),
-                name=monitor.get("name"),
-                unique_id=monitor.get("unique_id"),
-                output=monitor.get("output"),
-            )
+            region = {
+                "left": monitor["left"],
+                "top": monitor["top"],
+                "width": monitor["width"],
+                "height": monitor["height"],
+            }
 
-        if monitor.width <= 0 or monitor.height <= 0:
-            msg = f"Region has zero or negative size: {monitor!r}"
+        if region["width"] <= 0 or region["height"] <= 0:
+            msg = f"Region has zero or negative size: {region!r}"
             raise ScreenShotError(msg)
 
         with self._lock:
-            img_data_and_maybe_size = self._impl.grab(monitor)
+            img_data_and_maybe_size = self._impl.grab(region)
             if isinstance(img_data_and_maybe_size, tuple):
                 img_data, size = img_data_and_maybe_size
-                screenshot = self.cls_image(img_data, monitor, size=size)
+                screenshot = self.cls_image(img_data, region, size=size)
             else:
                 img_data = img_data_and_maybe_size
-                screenshot = self.cls_image(img_data, monitor)
+                screenshot = self.cls_image(img_data, region)
             if self._impl.with_cursor and (cursor := self._impl.cursor()):
                 return self._merge(screenshot, cursor)
             return screenshot

--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Buffer, Self
 
-    from mss.models import CaptureRegion, Monitors, Size
+    from mss.models import Monitors, Region, Size
 
 try:
     from datetime import UTC
@@ -90,7 +90,7 @@ class MSSImplementation(ABC):
         """Retrieve all cursor data. Pixels have to be RGB."""
 
     @abstractmethod
-    def grab(self, region: CaptureRegion, /) -> Buffer | tuple[Buffer, Size]:
+    def grab(self, region: Region, /) -> Buffer | tuple[Buffer, Size]:
         """Retrieve all pixels from a capture region. Pixels have to be RGB.
 
         Return ``(buffer, size)`` when the pixel dimensions of the returned
@@ -307,14 +307,14 @@ class MSS:
         """
         # Convert PIL bbox style
         if isinstance(monitor, tuple):
-            region: CaptureRegion = {
+            region: Region = {
                 "left": monitor[0],
                 "top": monitor[1],
                 "width": monitor[2] - monitor[0],
                 "height": monitor[3] - monitor[1],
             }
         elif isinstance(monitor, Monitor):
-            region = monitor.as_capture_region()
+            region = monitor.as_region()
         elif isinstance(monitor, dict):
             region = {
                 "left": monitor["left"],

--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -11,7 +11,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 from mss.exception import ScreenShotError
-from mss.models import Monitor
+from mss.models import Monitor, Region
 from mss.screenshot import ScreenShot
 from mss.tools import to_png
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Buffer, Self
 
-    from mss.models import Monitors, Region, Size
+    from mss.models import Monitors, Size
 
 try:
     from datetime import UTC
@@ -295,11 +295,11 @@ class MSS:
             self._impl.close()
             self._closed = True
 
-    def grab(self, monitor: Monitor | dict[str, Any] | tuple[int, int, int, int], /) -> ScreenShot:
+    def grab(self, monitor: Monitor | Region | dict[str, Any] | tuple[int, int, int, int], /) -> ScreenShot:
         """Retrieve screen pixels for a given monitor.
 
-        Note: ``monitor`` can be a tuple like the one
-        :py:func:`PIL.ImageGrab.grab` accepts: ``(left, top, right, bottom)``
+        ``monitor`` can be a :class:`mss.models.Monitor`, a :class:`mss.models.Region`, a region dictionary, or a tuple
+        like the one :py:func:`PIL.ImageGrab.grab` accepts: ``(left, top, right, bottom)``.
 
         :param monitor: The coordinates and size of the box to capture.
                         See :meth:`monitors <monitors>` for object details.
@@ -307,23 +307,25 @@ class MSS:
         """
         # Convert PIL bbox style
         if isinstance(monitor, tuple):
-            region: Region = {
-                "left": monitor[0],
-                "top": monitor[1],
-                "width": monitor[2] - monitor[0],
-                "height": monitor[3] - monitor[1],
-            }
+            region = Region(
+                left=monitor[0],
+                top=monitor[1],
+                width=monitor[2] - monitor[0],
+                height=monitor[3] - monitor[1],
+            )
         elif isinstance(monitor, Monitor):
             region = monitor.as_region()
+        elif isinstance(monitor, Region):
+            region = monitor
         elif isinstance(monitor, dict):
-            region = {
-                "left": monitor["left"],
-                "top": monitor["top"],
-                "width": monitor["width"],
-                "height": monitor["height"],
-            }
+            region = Region(
+                left=monitor["left"],
+                top=monitor["top"],
+                width=monitor["width"],
+                height=monitor["height"],
+            )
 
-        if region["width"] <= 0 or region["height"] <= 0:
+        if region.width <= 0 or region.height <= 0:
             msg = f"Region has zero or negative size: {region!r}"
             raise ScreenShotError(msg)
 

--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -11,6 +11,7 @@ from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 from mss.exception import ScreenShotError
+from mss.models import Monitor
 from mss.screenshot import ScreenShot
 from mss.tools import to_png
 
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 
     from typing_extensions import Buffer, Self
 
-    from mss.models import Monitor, Monitors, Size
+    from mss.models import Monitors, Size
 
 try:
     from datetime import UTC
@@ -291,7 +292,7 @@ class MSS:
             self._impl.close()
             self._closed = True
 
-    def grab(self, monitor: Monitor | tuple[int, int, int, int], /) -> ScreenShot:
+    def grab(self, monitor: Monitor | dict[str, Any] | tuple[int, int, int, int], /) -> ScreenShot:
         """Retrieve screen pixels for a given monitor.
 
         Note: ``monitor`` can be a tuple like the one
@@ -303,14 +304,25 @@ class MSS:
         """
         # Convert PIL bbox style
         if isinstance(monitor, tuple):
-            monitor = {
-                "left": monitor[0],
-                "top": monitor[1],
-                "width": monitor[2] - monitor[0],
-                "height": monitor[3] - monitor[1],
-            }
+            monitor = Monitor(
+                left=monitor[0],
+                top=monitor[1],
+                width=monitor[2] - monitor[0],
+                height=monitor[3] - monitor[1],
+            )
+        elif isinstance(monitor, dict):
+            monitor = Monitor(
+                left=monitor["left"],
+                top=monitor["top"],
+                width=monitor["width"],
+                height=monitor["height"],
+                is_primary=monitor.get("is_primary"),
+                name=monitor.get("name"),
+                unique_id=monitor.get("unique_id"),
+                output=monitor.get("output"),
+            )
 
-        if monitor["width"] <= 0 or monitor["height"] <= 0:
+        if monitor.width <= 0 or monitor.height <= 0:
             msg = f"Region has zero or negative size: {monitor!r}"
             raise ScreenShotError(msg)
 
@@ -335,19 +347,19 @@ class MSS:
         This method has to fill ``self._monitors`` with all information
         and use it as a cache:
 
-        - ``self._monitors[0]`` is a dict of all monitors together
-        - ``self._monitors[N]`` is a dict of the monitor N (with N > 0)
+        - ``self._monitors[0]`` is all monitors together
+        - ``self._monitors[N]`` is monitor N (with N > 0)
 
-        Each monitor is a dict with:
+        Each :class:`mss.models.Monitor` has:
 
         - ``left``: the x-coordinate of the upper-left corner
         - ``top``: the y-coordinate of the upper-left corner
         - ``width``: the width
         - ``height``: the height
-        - ``is_primary``: (optional) true if this is the primary monitor
-        - ``name``: (optional) human-readable device name
-        - ``unique_id``: (optional) platform-specific stable identifier for the monitor
-        - ``output``: (optional, Linux only) monitor output name, compatible with xrandr
+        - ``is_primary``: true or false when known, otherwise ``None``
+        - ``name``: human-readable device name, or ``None``
+        - ``unique_id``: platform-specific stable identifier, or ``None``
+        - ``output``: Linux output name compatible with xrandr, or ``None``
         """
         with self._lock:
             if self._monitors is None:
@@ -376,7 +388,7 @@ class MSS:
             (
                 monitor
                 for monitor in monitors[1:]  # Skip the "all monitors" entry at index 0
-                if monitor.get("is_primary", False)
+                if monitor.is_primary
             ),
             monitors[1],  # Fallback to the first monitor if no primary is found
         )
@@ -396,7 +408,9 @@ class MSS:
             grabs monitor ``N``.
         :param str output: The output filename. Keywords: ``{mon}``,
             ``{top}``, ``{left}``, ``{width}``, ``{height}``,
-            ``{date}``.
+            ``{is_primary}``, ``{name}``, ``{unique_id}``, ``{output}``,
+            ``{date}``. Optional metadata is formatted as ``None`` when
+            unavailable.
         :param typing.Callable callback: Called before saving the
             screenshot; receives the ``output`` argument.
         :return: Created file(s).
@@ -409,7 +423,18 @@ class MSS:
         if mon == 0:
             # One screenshot by monitor
             for idx, monitor in enumerate(monitors[1:], 1):
-                fname = output.format(mon=idx, date=datetime.now(UTC) if "{date" in output else None, **monitor)
+                fname = output.format(
+                    mon=idx,
+                    date=datetime.now(UTC) if "{date" in output else None,
+                    top=monitor.top,
+                    left=monitor.left,
+                    width=monitor.width,
+                    height=monitor.height,
+                    is_primary=monitor.is_primary,
+                    name=monitor.name,
+                    unique_id=monitor.unique_id,
+                    output=monitor.output,
+                )
                 if callable(callback):
                     callback(fname)
                 sct = self.grab(monitor)
@@ -425,7 +450,18 @@ class MSS:
                 msg = f"Monitor {mon!r} does not exist."
                 raise ScreenShotError(msg) from exc
 
-            output = output.format(mon=mon, date=datetime.now(UTC) if "{date" in output else None, **monitor)
+            output = output.format(
+                mon=mon,
+                date=datetime.now(UTC) if "{date" in output else None,
+                top=monitor.top,
+                left=monitor.left,
+                width=monitor.width,
+                height=monitor.height,
+                is_primary=monitor.is_primary,
+                name=monitor.name,
+                unique_id=monitor.unique_id,
+                output=monitor.output,
+            )
             if callable(callback):
                 callback(output)
             sct = self.grab(monitor)

--- a/src/mss/base.py
+++ b/src/mss/base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import platform
 import warnings
 from abc import ABC, abstractmethod
+from copy import copy
 from datetime import datetime
 from threading import Lock
 from typing import TYPE_CHECKING, Any
@@ -295,48 +296,47 @@ class MSS:
             self._impl.close()
             self._closed = True
 
-    def grab(self, monitor: Monitor | Region | dict[str, Any] | tuple[int, int, int, int], /) -> ScreenShot:
-        """Retrieve screen pixels for a given monitor.
+    def grab(self, region: Monitor | Region | dict[str, Any] | tuple[int, int, int, int], /) -> ScreenShot:
+        """Retrieve screen pixels for a given region.
 
-        ``monitor`` can be a :class:`mss.models.Monitor`, a :class:`mss.models.Region`, a region dictionary, or a tuple
+        ``region`` can be a :class:`mss.models.Monitor`, a :class:`mss.models.Region`, a region dictionary, or a tuple
         like the one :py:func:`PIL.ImageGrab.grab` accepts: ``(left, top, right, bottom)``.
 
-        :param monitor: The coordinates and size of the box to capture.
-                        See :meth:`monitors <monitors>` for object details.
+        :param region: The coordinates and size of the box to capture.
+                       See :meth:`monitors <monitors>` for monitor object details.
         :returns: Screenshot of the requested region.
         """
-        # Convert PIL bbox style
-        if isinstance(monitor, tuple):
-            region = Region(
-                left=monitor[0],
-                top=monitor[1],
-                width=monitor[2] - monitor[0],
-                height=monitor[3] - monitor[1],
+        if isinstance(region, tuple):
+            grab_region = Region(
+                left=region[0],
+                top=region[1],
+                width=region[2] - region[0],
+                height=region[3] - region[1],
             )
-        elif isinstance(monitor, Monitor):
-            region = monitor.as_region()
-        elif isinstance(monitor, Region):
-            region = monitor
-        elif isinstance(monitor, dict):
-            region = Region(
-                left=monitor["left"],
-                top=monitor["top"],
-                width=monitor["width"],
-                height=monitor["height"],
+        elif isinstance(region, Monitor):
+            grab_region = region.as_region()
+        elif isinstance(region, Region):
+            grab_region = copy(region)
+        elif isinstance(region, dict):
+            grab_region = Region(
+                left=region["left"],
+                top=region["top"],
+                width=region["width"],
+                height=region["height"],
             )
 
-        if region.width <= 0 or region.height <= 0:
-            msg = f"Region has zero or negative size: {region!r}"
+        if grab_region.width <= 0 or grab_region.height <= 0:
+            msg = f"Region has zero or negative size: {grab_region!r}"
             raise ScreenShotError(msg)
 
         with self._lock:
-            img_data_and_maybe_size = self._impl.grab(region)
+            img_data_and_maybe_size = self._impl.grab(grab_region)
             if isinstance(img_data_and_maybe_size, tuple):
                 img_data, size = img_data_and_maybe_size
-                screenshot = self.cls_image(img_data, region, size=size)
+                screenshot = self.cls_image(img_data, grab_region, size=size)
             else:
                 img_data = img_data_and_maybe_size
-                screenshot = self.cls_image(img_data, region)
+                screenshot = self.cls_image(img_data, grab_region)
             if self._impl.with_cursor and (cursor := self._impl.cursor()):
                 return self._merge(screenshot, cursor)
             return screenshot

--- a/src/mss/darwin.py
+++ b/src/mss/darwin.py
@@ -229,7 +229,7 @@ class MSSImplDarwin(MSSImplementation):
     def grab(self, region: Region, /) -> tuple[bytearray, Size]:
         """Retrieve all pixels from a capture region. Pixels have to be RGB."""
         core = self.core
-        rect = CGRect((region["left"], region["top"]), (region["width"], region["height"]))
+        rect = CGRect((region.left, region.top), (region.width, region.height))
 
         image_ref = core.CGWindowListCreateImage(rect, 1, 0, IMAGE_OPTIONS)
         if not image_ref:

--- a/src/mss/darwin.py
+++ b/src/mss/darwin.py
@@ -28,12 +28,13 @@ from typing import TYPE_CHECKING
 from mss.base import MSS as _MSS
 from mss.base import MSSImplementation
 from mss.exception import ScreenShotError
+from mss.models import Monitor
 from mss.screenshot import Size
 
 if TYPE_CHECKING:
     from typing import Any
 
-    from mss.models import CFunctions, Monitor, Monitors
+    from mss.models import CFunctions, Monitors
 
 __all__ = ("IMAGE_OPTIONS", "MSS")
 
@@ -184,8 +185,6 @@ class MSSImplDarwin(MSSImplementation):
         # We need to update the value with every single monitor found
         # using CGRectUnion.  Else we will end with infinite values.
         all_monitors = CGRect()
-        monitors.append({})
-
         # Each monitor
         display_count = c_uint32(0)
         active_displays = (c_uint32 * self.max_displays)()
@@ -203,31 +202,34 @@ class MSSImplDarwin(MSSImplementation):
                 width, height = height, width
 
             monitors.append(
-                {
-                    "left": int_(rect.origin.x),
-                    "top": int_(rect.origin.y),
-                    "width": int_(width),
-                    "height": int_(height),
-                },
+                Monitor(
+                    left=int_(rect.origin.x),
+                    top=int_(rect.origin.y),
+                    width=int_(width),
+                    height=int_(height),
+                ),
             )
 
             # Update AiO monitor's values
             all_monitors = core.CGRectUnion(all_monitors, rect)
 
         # Set the AiO monitor's values
-        monitors[0] = {
-            "left": int_(all_monitors.origin.x),
-            "top": int_(all_monitors.origin.y),
-            "width": int_(all_monitors.size.width),
-            "height": int_(all_monitors.size.height),
-        }
+        monitors.insert(
+            0,
+            Monitor(
+                left=int_(all_monitors.origin.x),
+                top=int_(all_monitors.origin.y),
+                width=int_(all_monitors.size.width),
+                height=int_(all_monitors.size.height),
+            ),
+        )
 
         return monitors
 
     def grab(self, monitor: Monitor, /) -> tuple[bytearray, Size]:
         """Retrieve all pixels from a monitor. Pixels have to be RGB."""
         core = self.core
-        rect = CGRect((monitor["left"], monitor["top"]), (monitor["width"], monitor["height"]))
+        rect = CGRect((monitor.left, monitor.top), (monitor.width, monitor.height))
 
         image_ref = core.CGWindowListCreateImage(rect, 1, 0, IMAGE_OPTIONS)
         if not image_ref:

--- a/src/mss/darwin.py
+++ b/src/mss/darwin.py
@@ -34,7 +34,7 @@ from mss.screenshot import Size
 if TYPE_CHECKING:
     from typing import Any
 
-    from mss.models import CaptureRegion, CFunctions, Monitors
+    from mss.models import CFunctions, Monitors, Region
 
 __all__ = ("IMAGE_OPTIONS", "MSS")
 
@@ -226,7 +226,7 @@ class MSSImplDarwin(MSSImplementation):
 
         return monitors
 
-    def grab(self, region: CaptureRegion, /) -> tuple[bytearray, Size]:
+    def grab(self, region: Region, /) -> tuple[bytearray, Size]:
         """Retrieve all pixels from a capture region. Pixels have to be RGB."""
         core = self.core
         rect = CGRect((region["left"], region["top"]), (region["width"], region["height"]))

--- a/src/mss/darwin.py
+++ b/src/mss/darwin.py
@@ -34,7 +34,7 @@ from mss.screenshot import Size
 if TYPE_CHECKING:
     from typing import Any
 
-    from mss.models import CFunctions, Monitors
+    from mss.models import CaptureRegion, CFunctions, Monitors
 
 __all__ = ("IMAGE_OPTIONS", "MSS")
 
@@ -226,10 +226,10 @@ class MSSImplDarwin(MSSImplementation):
 
         return monitors
 
-    def grab(self, monitor: Monitor, /) -> tuple[bytearray, Size]:
-        """Retrieve all pixels from a monitor. Pixels have to be RGB."""
+    def grab(self, region: CaptureRegion, /) -> tuple[bytearray, Size]:
+        """Retrieve all pixels from a capture region. Pixels have to be RGB."""
         core = self.core
-        rect = CGRect((monitor.left, monitor.top), (monitor.width, monitor.height))
+        rect = CGRect((region["left"], region["top"]), (region["width"], region["height"]))
 
         image_ref = core.CGWindowListCreateImage(rect, 1, 0, IMAGE_OPTIONS)
         if not image_ref:

--- a/src/mss/linux/base.py
+++ b/src/mss/linux/base.py
@@ -7,14 +7,14 @@ from mss.base import MSSImplementation
 from mss.exception import ScreenShotError
 from mss.linux import xcb
 from mss.linux.xcb import LIB
-from mss.models import Monitor
+from mss.models import Monitor, Region
 from mss.screenshot import ScreenShot
 from mss.tools import parse_edid
 
 if TYPE_CHECKING:
     from ctypes import Array
 
-    from mss.models import Monitors, Region
+    from mss.models import Monitors
 
 __all__ = ()
 
@@ -421,12 +421,12 @@ class MSSImplXCBBase(MSSImplementation):
             raise ScreenShotError(msg)
 
         cursor_img = xcb.xfixes_get_cursor_image(self.conn)
-        region: Region = {
-            "left": cursor_img.x - cursor_img.xhot,
-            "top": cursor_img.y - cursor_img.yhot,
-            "width": cursor_img.width,
-            "height": cursor_img.height,
-        }
+        region = Region(
+            left=cursor_img.x - cursor_img.xhot,
+            top=cursor_img.y - cursor_img.yhot,
+            width=cursor_img.width,
+            height=cursor_img.height,
+        )
 
         data_arr = xcb.xfixes_get_cursor_image_cursor_image(cursor_img)
         data = bytearray(data_arr)
@@ -454,10 +454,10 @@ class MSSImplXCBBase(MSSImplementation):
             self.conn,
             xcb.ImageFormat.ZPixmap,
             self.drawable,
-            region["left"],
-            region["top"],
-            region["width"],
-            region["height"],
+            region.left,
+            region.top,
+            region.width,
+            region.height,
             ALL_PLANES,
         )
 

--- a/src/mss/linux/base.py
+++ b/src/mss/linux/base.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from urllib.parse import urlencode
 
 from mss.base import MSSImplementation
 from mss.exception import ScreenShotError
 from mss.linux import xcb
 from mss.linux.xcb import LIB
+from mss.models import Monitor
 from mss.screenshot import ScreenShot
 from mss.tools import parse_edid
 
 if TYPE_CHECKING:
     from ctypes import Array
 
-    from mss.models import Monitor, Monitors
+    from mss.models import Monitors
 
 __all__ = ()
 
@@ -183,12 +184,12 @@ class MSSImplXCBBase(MSSImplementation):
             raise ScreenShotError(msg)
 
         root_geom = xcb.get_geometry(self.conn, self.root)
-        return {
-            "left": root_geom.x,
-            "top": root_geom.y,
-            "width": root_geom.width,
-            "height": root_geom.height,
-        }
+        return Monitor(
+            left=root_geom.x,
+            top=root_geom.y,
+            width=root_geom.width,
+            height=root_geom.height,
+        )
 
     def _randr_get_version(self) -> tuple[int, int] | None:
         if self.conn is None:
@@ -232,7 +233,7 @@ class MSSImplXCBBase(MSSImplementation):
         timestamp: xcb.Timestamp,
         edid_atom: xcb.Atom | None,
         /,
-    ) -> dict[str, Any]:
+    ) -> dict[str, str]:
         if self.conn is None:
             msg = "Cannot identify monitors while the connection is closed"
             raise ScreenShotError(msg)
@@ -242,7 +243,7 @@ class MSSImplXCBBase(MSSImplementation):
             msg = "Display configuration changed while detecting monitors."
             raise ScreenShotError(msg)
 
-        rv: dict[str, Any] = {}
+        rv: dict[str, str] = {}
 
         output_name_arr = xcb.randr_get_output_info_name(output_info)
         rv["output"] = bytes(output_name_arr).decode("utf_8", errors="replace")
@@ -305,24 +306,31 @@ class MSSImplXCBBase(MSSImplementation):
         monitors_reply = xcb.randr_get_monitors(self.conn, self.drawable, 1)
         timestamp = monitors_reply.timestamp
         for randr_monitor in xcb.randr_get_monitors_monitors(monitors_reply):
-            monitor = {
-                "left": randr_monitor.x,
-                "top": randr_monitor.y,
-                "width": randr_monitor.width,
-                "height": randr_monitor.height,
-                # Under XRandR, it's legal for no monitor to be primary.  In this case, case MSSBase.primary_monitor
-                # will return the first monitor.  That said, we note in the dict that we explicitly are told by XRandR
-                # that all of the monitors are not primary.  (This is distinct from the XRandR 1.2 path, which doesn't
-                # have any information about primary monitors.)
-                "is_primary": bool(randr_monitor.primary),
-            }
-
+            output_ids: dict[str, str] = {}
             if randr_monitor.nOutput > 0:
                 outputs = xcb.randr_monitor_info_outputs(randr_monitor)
                 chosen_output = self._choose_randr_output(outputs, primary_output)
-                monitor |= self._randr_output_ids(chosen_output, timestamp, edid_atom)
+                output_ids = self._randr_output_ids(chosen_output, timestamp, edid_atom)
 
-            monitors.append(monitor)
+            monitors.append(
+                Monitor(
+                    left=randr_monitor.x,
+                    top=randr_monitor.y,
+                    width=randr_monitor.width,
+                    height=randr_monitor.height,
+                    # Under XRandR, it's legal for no monitor to be primary.  In
+                    # this case, case MSSBase.primary_monitor will return the
+                    # first monitor.  That said, we note in the dict that we
+                    # explicitly are told by XRandR that all of the monitors are
+                    # not primary.  (This is distinct from the XRandR 1.2 path,
+                    # which doesn't have any information about primary
+                    # monitors.)
+                    is_primary=bool(randr_monitor.primary),
+                    name=output_ids.get("name"),
+                    unique_id=output_ids.get("unique_id"),
+                    output=output_ids.get("output"),
+                ),
+            )
 
         return monitors
 
@@ -352,23 +360,24 @@ class MSSImplXCBBase(MSSImplementation):
             crtc_info = xcb.randr_get_crtc_info(self.conn, crtc, timestamp)
             if crtc_info.num_outputs == 0:
                 continue
-            monitor = {
-                "left": crtc_info.x,
-                "top": crtc_info.y,
-                "width": crtc_info.width,
-                "height": crtc_info.height,
-            }
-
             outputs = xcb.randr_get_crtc_info_outputs(crtc_info)
             chosen_output = self._choose_randr_output(outputs, primary_output)
-            monitor |= self._randr_output_ids(chosen_output, timestamp, edid_atom)
+            output_ids = self._randr_output_ids(chosen_output, timestamp, edid_atom)
             # The concept of primary outputs was added in XRandR 1.3.  We distinguish between "all the monitors are
             # not primary" (RRGetOutputPrimary returned XCB_NONE, a valid case) and "we have no way to get
-            # information about the primary monitor": in the latter case, we don't populate "is_primary".
-            if primary_output is not None:
-                monitor["is_primary"] = chosen_output == primary_output
-
-            monitors.append(monitor)
+            # information about the primary monitor": in the latter case, is_primary is None.
+            monitors.append(
+                Monitor(
+                    left=crtc_info.x,
+                    top=crtc_info.y,
+                    width=crtc_info.width,
+                    height=crtc_info.height,
+                    is_primary=chosen_output == primary_output if primary_output is not None else None,
+                    name=output_ids.get("name"),
+                    unique_id=output_ids.get("unique_id"),
+                    output=output_ids.get("output"),
+                ),
+            )
 
         return monitors
 
@@ -443,10 +452,10 @@ class MSSImplXCBBase(MSSImplementation):
             self.conn,
             xcb.ImageFormat.ZPixmap,
             self.drawable,
-            monitor["left"],
-            monitor["top"],
-            monitor["width"],
-            monitor["height"],
+            monitor.left,
+            monitor.top,
+            monitor.width,
+            monitor.height,
             ALL_PLANES,
         )
 

--- a/src/mss/linux/base.py
+++ b/src/mss/linux/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 from urllib.parse import urlencode
 
 from mss.base import MSSImplementation
@@ -14,7 +14,7 @@ from mss.tools import parse_edid
 if TYPE_CHECKING:
     from ctypes import Array
 
-    from mss.models import Monitors
+    from mss.models import CaptureRegion, Monitors
 
 __all__ = ()
 
@@ -24,6 +24,12 @@ SUPPORTED_RED_MASK = 0xFF0000
 SUPPORTED_GREEN_MASK = 0x00FF00
 SUPPORTED_BLUE_MASK = 0x0000FF
 ALL_PLANES = 0xFFFFFFFF  # XCB doesn't define AllPlanes
+
+
+class _RandROutputIds(TypedDict, total=False):
+    name: str
+    unique_id: str
+    output: str
 
 
 class MSSImplXCBBase(MSSImplementation):
@@ -233,7 +239,7 @@ class MSSImplXCBBase(MSSImplementation):
         timestamp: xcb.Timestamp,
         edid_atom: xcb.Atom | None,
         /,
-    ) -> dict[str, str]:
+    ) -> _RandROutputIds:
         if self.conn is None:
             msg = "Cannot identify monitors while the connection is closed"
             raise ScreenShotError(msg)
@@ -243,7 +249,7 @@ class MSSImplXCBBase(MSSImplementation):
             msg = "Display configuration changed while detecting monitors."
             raise ScreenShotError(msg)
 
-        rv: dict[str, str] = {}
+        rv: _RandROutputIds = {}
 
         output_name_arr = xcb.randr_get_output_info_name(output_info)
         rv["output"] = bytes(output_name_arr).decode("utf_8", errors="replace")
@@ -306,7 +312,7 @@ class MSSImplXCBBase(MSSImplementation):
         monitors_reply = xcb.randr_get_monitors(self.conn, self.drawable, 1)
         timestamp = monitors_reply.timestamp
         for randr_monitor in xcb.randr_get_monitors_monitors(monitors_reply):
-            output_ids: dict[str, str] = {}
+            output_ids: _RandROutputIds = {}
             if randr_monitor.nOutput > 0:
                 outputs = xcb.randr_monitor_info_outputs(randr_monitor)
                 chosen_output = self._choose_randr_output(outputs, primary_output)
@@ -320,15 +326,13 @@ class MSSImplXCBBase(MSSImplementation):
                     height=randr_monitor.height,
                     # Under XRandR, it's legal for no monitor to be primary.  In
                     # this case, case MSSBase.primary_monitor will return the
-                    # first monitor.  That said, we note in the dict that we
+                    # first monitor.  That said, we note in the Monitor that we
                     # explicitly are told by XRandR that all of the monitors are
                     # not primary.  (This is distinct from the XRandR 1.2 path,
                     # which doesn't have any information about primary
                     # monitors.)
                     is_primary=bool(randr_monitor.primary),
-                    name=output_ids.get("name"),
-                    unique_id=output_ids.get("unique_id"),
-                    output=output_ids.get("output"),
+                    **output_ids,
                 ),
             )
 
@@ -373,9 +377,7 @@ class MSSImplXCBBase(MSSImplementation):
                     width=crtc_info.width,
                     height=crtc_info.height,
                     is_primary=chosen_output == primary_output if primary_output is not None else None,
-                    name=output_ids.get("name"),
-                    unique_id=output_ids.get("unique_id"),
-                    output=output_ids.get("output"),
+                    **output_ids,
                 ),
             )
 
@@ -419,7 +421,7 @@ class MSSImplXCBBase(MSSImplementation):
             raise ScreenShotError(msg)
 
         cursor_img = xcb.xfixes_get_cursor_image(self.conn)
-        region = {
+        region: CaptureRegion = {
             "left": cursor_img.x - cursor_img.xhot,
             "top": cursor_img.y - cursor_img.yhot,
             "width": cursor_img.width,
@@ -433,13 +435,13 @@ class MSSImplXCBBase(MSSImplementation):
 
         return ScreenShot(data, region)
 
-    def _grab_xgetimage(self, monitor: Monitor, /) -> bytearray:
-        """Retrieve pixels from a monitor using ``GetImage``.
+    def _grab_xgetimage(self, region: CaptureRegion, /) -> bytearray:
+        """Retrieve pixels from a capture region using ``GetImage``.
 
         Used by the XGetImage backend and by the XShmGetImage backend in
         fallback mode.
 
-        :param monitor: Monitor rectangle specifying ``left``, ``top``,
+        :param region: Rectangle specifying ``left``, ``top``,
             ``width``, and ``height`` to capture.
         :returns: A screenshot object containing the captured region.
         """
@@ -452,10 +454,10 @@ class MSSImplXCBBase(MSSImplementation):
             self.conn,
             xcb.ImageFormat.ZPixmap,
             self.drawable,
-            monitor.left,
-            monitor.top,
-            monitor.width,
-            monitor.height,
+            region["left"],
+            region["top"],
+            region["width"],
+            region["height"],
             ALL_PLANES,
         )
 

--- a/src/mss/linux/base.py
+++ b/src/mss/linux/base.py
@@ -14,7 +14,7 @@ from mss.tools import parse_edid
 if TYPE_CHECKING:
     from ctypes import Array
 
-    from mss.models import CaptureRegion, Monitors
+    from mss.models import Monitors, Region
 
 __all__ = ()
 
@@ -421,7 +421,7 @@ class MSSImplXCBBase(MSSImplementation):
             raise ScreenShotError(msg)
 
         cursor_img = xcb.xfixes_get_cursor_image(self.conn)
-        region: CaptureRegion = {
+        region: Region = {
             "left": cursor_img.x - cursor_img.xhot,
             "top": cursor_img.y - cursor_img.yhot,
             "width": cursor_img.width,
@@ -435,7 +435,7 @@ class MSSImplXCBBase(MSSImplementation):
 
         return ScreenShot(data, region)
 
-    def _grab_xgetimage(self, region: CaptureRegion, /) -> bytearray:
+    def _grab_xgetimage(self, region: Region, /) -> bytearray:
         """Retrieve pixels from a capture region using ``GetImage``.
 
         Used by the XGetImage backend and by the XShmGetImage backend in

--- a/src/mss/linux/xgetimage.py
+++ b/src/mss/linux/xgetimage.py
@@ -10,7 +10,7 @@ backend.
 """
 
 from mss.linux.base import MSSImplXCBBase
-from mss.models import CaptureRegion
+from mss.models import Region
 
 __all__ = ()
 
@@ -23,6 +23,6 @@ class MSSImplXGetImage(MSSImplXCBBase):
             Lists constructor parameters.
     """
 
-    def grab(self, region: CaptureRegion) -> bytearray:
+    def grab(self, region: Region) -> bytearray:
         """Retrieve all pixels from a capture region. Pixels have to be RGBX."""
         return super()._grab_xgetimage(region)

--- a/src/mss/linux/xgetimage.py
+++ b/src/mss/linux/xgetimage.py
@@ -10,7 +10,7 @@ backend.
 """
 
 from mss.linux.base import MSSImplXCBBase
-from mss.models import Monitor
+from mss.models import CaptureRegion
 
 __all__ = ()
 
@@ -23,6 +23,6 @@ class MSSImplXGetImage(MSSImplXCBBase):
             Lists constructor parameters.
     """
 
-    def grab(self, monitor: Monitor) -> bytearray:
-        """Retrieve all pixels from a monitor. Pixels have to be RGBX."""
-        return super()._grab_xgetimage(monitor)
+    def grab(self, region: CaptureRegion) -> bytearray:
+        """Retrieve all pixels from a capture region. Pixels have to be RGBX."""
+        return super()._grab_xgetimage(region)

--- a/src/mss/linux/xlib.py
+++ b/src/mss/linux/xlib.py
@@ -43,7 +43,7 @@ from mss.screenshot import ScreenShot
 if TYPE_CHECKING:
     from threading import Thread
 
-    from mss.models import CFunctions, Monitors
+    from mss.models import CaptureRegion, CFunctions, Monitors
 
 __all__ = ()
 
@@ -580,17 +580,17 @@ class MSSImplXlib(MSSImplementation):
 
         return monitors
 
-    def grab(self, monitor: Monitor, /) -> bytearray:
-        """Retrieve all pixels from a monitor. Pixels have to be RGB."""
+    def grab(self, region: CaptureRegion, /) -> bytearray:
+        """Retrieve all pixels from a capture region. Pixels have to be RGB."""
 
         with _lock:
             ximage = self.xlib.XGetImage(
                 self._handles.display,
                 self._handles.drawable,
-                monitor.left,
-                monitor.top,
-                monitor.width,
-                monitor.height,
+                region["left"],
+                region["top"],
+                region["width"],
+                region["height"],
                 PLAINMASK,
                 ZPIXMAP,
             )
@@ -603,7 +603,7 @@ class MSSImplXlib(MSSImplementation):
 
             raw_data = cast(
                 ximage.contents.data,
-                POINTER(c_ubyte * monitor.height * monitor.width * 4),
+                POINTER(c_ubyte * region["height"] * region["width"] * 4),
             )
             data = bytearray(raw_data.contents)
         finally:
@@ -626,7 +626,7 @@ class MSSImplXlib(MSSImplementation):
             raise ScreenShotError(msg)
 
         cursor_img: XFixesCursorImage = ximage.contents
-        region = {
+        region: CaptureRegion = {
             "left": cursor_img.x - cursor_img.xhot,
             "top": cursor_img.y - cursor_img.yhot,
             "width": cursor_img.width,

--- a/src/mss/linux/xlib.py
+++ b/src/mss/linux/xlib.py
@@ -37,12 +37,13 @@ from typing import TYPE_CHECKING, Any
 
 from mss.base import MSSImplementation
 from mss.exception import ScreenShotError
+from mss.models import Monitor
 from mss.screenshot import ScreenShot
 
 if TYPE_CHECKING:
     from threading import Thread
 
-    from mss.models import CFunctions, Monitor, Monitors
+    from mss.models import CFunctions, Monitors
 
 __all__ = ()
 
@@ -544,7 +545,7 @@ class MSSImplXlib(MSSImplementation):
             gwa = XWindowAttributes()
             self.xlib.XGetWindowAttributes(display, self._handles.root, byref(gwa))
             monitors.append(
-                {"left": int_(gwa.x), "top": int_(gwa.y), "width": int_(gwa.width), "height": int_(gwa.height)},
+                Monitor(left=int_(gwa.x), top=int_(gwa.y), width=int_(gwa.width), height=int_(gwa.height)),
             )
 
             # Each monitor
@@ -567,12 +568,12 @@ class MSSImplXlib(MSSImplementation):
                     continue
 
                 monitors.append(
-                    {
-                        "left": int_(crtc.x),
-                        "top": int_(crtc.y),
-                        "width": int_(crtc.width),
-                        "height": int_(crtc.height),
-                    },
+                    Monitor(
+                        left=int_(crtc.x),
+                        top=int_(crtc.y),
+                        width=int_(crtc.width),
+                        height=int_(crtc.height),
+                    ),
                 )
                 xrandr.XRRFreeCrtcInfo(crtc)
             xrandr.XRRFreeScreenResources(mon)
@@ -586,10 +587,10 @@ class MSSImplXlib(MSSImplementation):
             ximage = self.xlib.XGetImage(
                 self._handles.display,
                 self._handles.drawable,
-                monitor["left"],
-                monitor["top"],
-                monitor["width"],
-                monitor["height"],
+                monitor.left,
+                monitor.top,
+                monitor.width,
+                monitor.height,
                 PLAINMASK,
                 ZPIXMAP,
             )
@@ -602,7 +603,7 @@ class MSSImplXlib(MSSImplementation):
 
             raw_data = cast(
                 ximage.contents.data,
-                POINTER(c_ubyte * monitor["height"] * monitor["width"] * 4),
+                POINTER(c_ubyte * monitor.height * monitor.width * 4),
             )
             data = bytearray(raw_data.contents)
         finally:

--- a/src/mss/linux/xlib.py
+++ b/src/mss/linux/xlib.py
@@ -37,13 +37,13 @@ from typing import TYPE_CHECKING, Any
 
 from mss.base import MSSImplementation
 from mss.exception import ScreenShotError
-from mss.models import Monitor
+from mss.models import Monitor, Region
 from mss.screenshot import ScreenShot
 
 if TYPE_CHECKING:
     from threading import Thread
 
-    from mss.models import CFunctions, Monitors, Region
+    from mss.models import CFunctions, Monitors
 
 __all__ = ()
 
@@ -587,10 +587,10 @@ class MSSImplXlib(MSSImplementation):
             ximage = self.xlib.XGetImage(
                 self._handles.display,
                 self._handles.drawable,
-                region["left"],
-                region["top"],
-                region["width"],
-                region["height"],
+                region.left,
+                region.top,
+                region.width,
+                region.height,
                 PLAINMASK,
                 ZPIXMAP,
             )
@@ -603,7 +603,7 @@ class MSSImplXlib(MSSImplementation):
 
             raw_data = cast(
                 ximage.contents.data,
-                POINTER(c_ubyte * region["height"] * region["width"] * 4),
+                POINTER(c_ubyte * region.height * region.width * 4),
             )
             data = bytearray(raw_data.contents)
         finally:
@@ -626,17 +626,17 @@ class MSSImplXlib(MSSImplementation):
             raise ScreenShotError(msg)
 
         cursor_img: XFixesCursorImage = ximage.contents
-        region: Region = {
-            "left": cursor_img.x - cursor_img.xhot,
-            "top": cursor_img.y - cursor_img.yhot,
-            "width": cursor_img.width,
-            "height": cursor_img.height,
-        }
+        region = Region(
+            left=cursor_img.x - cursor_img.xhot,
+            top=cursor_img.y - cursor_img.yhot,
+            width=cursor_img.width,
+            height=cursor_img.height,
+        )
 
-        raw_data = cast(cursor_img.pixels, POINTER(c_ulong * region["height"] * region["width"]))
+        raw_data = cast(cursor_img.pixels, POINTER(c_ulong * region.height * region.width))
         raw = bytearray(raw_data.contents)
 
-        data = bytearray(region["height"] * region["width"] * 4)
+        data = bytearray(region.height * region.width * 4)
         data[3::4] = raw[3::8]
         data[2::4] = raw[2::8]
         data[1::4] = raw[1::8]

--- a/src/mss/linux/xlib.py
+++ b/src/mss/linux/xlib.py
@@ -43,7 +43,7 @@ from mss.screenshot import ScreenShot
 if TYPE_CHECKING:
     from threading import Thread
 
-    from mss.models import CaptureRegion, CFunctions, Monitors
+    from mss.models import CFunctions, Monitors, Region
 
 __all__ = ()
 
@@ -580,7 +580,7 @@ class MSSImplXlib(MSSImplementation):
 
         return monitors
 
-    def grab(self, region: CaptureRegion, /) -> bytearray:
+    def grab(self, region: Region, /) -> bytearray:
         """Retrieve all pixels from a capture region. Pixels have to be RGB."""
 
         with _lock:
@@ -626,7 +626,7 @@ class MSSImplXlib(MSSImplementation):
             raise ScreenShotError(msg)
 
         cursor_img: XFixesCursorImage = ximage.contents
-        region: CaptureRegion = {
+        region: Region = {
             "left": cursor_img.x - cursor_img.xhot,
             "top": cursor_img.y - cursor_img.yhot,
             "width": cursor_img.width,

--- a/src/mss/linux/xshmgetimage.py
+++ b/src/mss/linux/xshmgetimage.py
@@ -28,7 +28,7 @@ from mss.linux.base import ALL_PLANES, MSSImplXCBBase
 from mss.linux.xcbhelpers import LIB, XProtoError
 
 if TYPE_CHECKING:
-    from mss.models import CaptureRegion
+    from mss.models import Region
 
 __all__ = ()
 
@@ -282,7 +282,7 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
 
         return ShmStatus.UNKNOWN
 
-    def _grab_xshmgetimage(self, region: CaptureRegion) -> memoryview:
+    def _grab_xshmgetimage(self, region: Region) -> memoryview:
         """Capture a region directly into a shared-memory slot."""
         if self.conn is None:
             msg = "Cannot take screenshot while the connection is closed"
@@ -325,7 +325,7 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
             self._release_shm_slot(slot)
             raise
 
-    def grab(self, region: CaptureRegion) -> memoryview | bytearray:
+    def grab(self, region: Region) -> memoryview | bytearray:
         """Retrieve all pixels from a capture region. Pixels have to be RGBX."""
         if self.shm_status == ShmStatus.UNAVAILABLE:
             return super()._grab_xgetimage(region)

--- a/src/mss/linux/xshmgetimage.py
+++ b/src/mss/linux/xshmgetimage.py
@@ -291,7 +291,7 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
         # Presently, we request a buffer at least as big as our capture area.  Another option would be to request a
         # buffer at the root size: this uses more memory, but makes it more likely that the buffers can be reused after
         # window resizes.  This only matters if the initial buffers are in use still, and we have to create a new one.
-        required_size = monitor["width"] * monitor["height"] * 4
+        required_size = monitor.width * monitor.height * 4
         slot = self._acquire_shm_slot(required_size)
         assert slot.buf is not None  # noqa: S101
 
@@ -299,10 +299,10 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
             img_reply = xcb.shm_get_image(
                 self.conn,
                 self.drawable,
-                monitor["left"],
-                monitor["top"],
-                monitor["width"],
-                monitor["height"],
+                monitor.left,
+                monitor.top,
+                monitor.width,
+                monitor.height,
                 ALL_PLANES,
                 xcb.ImageFormat.ZPixmap,
                 slot.shmseg,

--- a/src/mss/linux/xshmgetimage.py
+++ b/src/mss/linux/xshmgetimage.py
@@ -291,7 +291,7 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
         # Presently, we request a buffer at least as big as our capture area.  Another option would be to request a
         # buffer at the root size: this uses more memory, but makes it more likely that the buffers can be reused after
         # window resizes.  This only matters if the initial buffers are in use still, and we have to create a new one.
-        required_size = region["width"] * region["height"] * 4
+        required_size = region.width * region.height * 4
         slot = self._acquire_shm_slot(required_size)
         assert slot.buf is not None  # noqa: S101
 
@@ -299,10 +299,10 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
             img_reply = xcb.shm_get_image(
                 self.conn,
                 self.drawable,
-                region["left"],
-                region["top"],
-                region["width"],
-                region["height"],
+                region.left,
+                region.top,
+                region.width,
+                region.height,
                 ALL_PLANES,
                 xcb.ImageFormat.ZPixmap,
                 slot.shmseg,

--- a/src/mss/linux/xshmgetimage.py
+++ b/src/mss/linux/xshmgetimage.py
@@ -28,7 +28,7 @@ from mss.linux.base import ALL_PLANES, MSSImplXCBBase
 from mss.linux.xcbhelpers import LIB, XProtoError
 
 if TYPE_CHECKING:
-    from mss.models import Monitor
+    from mss.models import CaptureRegion
 
 __all__ = ()
 
@@ -282,8 +282,8 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
 
         return ShmStatus.UNKNOWN
 
-    def _grab_xshmgetimage(self, monitor: Monitor) -> memoryview:
-        """Capture a monitor directly into a shared-memory slot."""
+    def _grab_xshmgetimage(self, region: CaptureRegion) -> memoryview:
+        """Capture a region directly into a shared-memory slot."""
         if self.conn is None:
             msg = "Cannot take screenshot while the connection is closed"
             raise ScreenShotError(msg)
@@ -291,7 +291,7 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
         # Presently, we request a buffer at least as big as our capture area.  Another option would be to request a
         # buffer at the root size: this uses more memory, but makes it more likely that the buffers can be reused after
         # window resizes.  This only matters if the initial buffers are in use still, and we have to create a new one.
-        required_size = monitor.width * monitor.height * 4
+        required_size = region["width"] * region["height"] * 4
         slot = self._acquire_shm_slot(required_size)
         assert slot.buf is not None  # noqa: S101
 
@@ -299,10 +299,10 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
             img_reply = xcb.shm_get_image(
                 self.conn,
                 self.drawable,
-                monitor.left,
-                monitor.top,
-                monitor.width,
-                monitor.height,
+                region["left"],
+                region["top"],
+                region["width"],
+                region["height"],
                 ALL_PLANES,
                 xcb.ImageFormat.ZPixmap,
                 slot.shmseg,
@@ -325,14 +325,14 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
             self._release_shm_slot(slot)
             raise
 
-    def grab(self, monitor: Monitor) -> memoryview | bytearray:
-        """Retrieve all pixels from a monitor. Pixels have to be RGBX."""
+    def grab(self, region: CaptureRegion) -> memoryview | bytearray:
+        """Retrieve all pixels from a capture region. Pixels have to be RGBX."""
         if self.shm_status == ShmStatus.UNAVAILABLE:
-            return super()._grab_xgetimage(monitor)
+            return super()._grab_xgetimage(region)
 
         # The usual path is just the next few lines.
         try:
-            rv: memoryview | bytearray = self._grab_xshmgetimage(monitor)
+            rv: memoryview | bytearray = self._grab_xshmgetimage(region)
             if self.shm_status != ShmStatus.AVAILABLE:
                 self.shm_status = ShmStatus.AVAILABLE
                 self.performance_status.append("MIT-SHM is working correctly.")
@@ -347,7 +347,7 @@ class MSSImplXShmGetImage(MSSImplXCBBase):
             # altogether: security-hardened servers, for instance, or some XPrint servers.  But let's make sure, by
             # testing the same request through XGetImage.
             try:
-                rv = super()._grab_xgetimage(monitor)
+                rv = super()._grab_xgetimage(region)
             except XProtoError:  # noqa: TRY203
                 # The XGetImage also failed, so we don't know anything about whether XShmGetImage is usable.  Maybe
                 # the user sent an out-of-bounds request.  Maybe it's a security-hardened server.  We're not sure what

--- a/src/mss/models.py
+++ b/src/mss/models.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 
 
-class Region(TypedDict):
-    """Rectangular screen region to capture."""
+@dataclass(slots=True)
+class Region:
+    """Rectangular screen region."""
 
     left: int
     top: int
@@ -42,12 +43,7 @@ class Monitor:
 
     def as_region(self) -> Region:
         """Return this monitor's geometry as a capture region."""
-        return {
-            "left": self.left,
-            "top": self.top,
-            "width": self.width,
-            "height": self.height,
-        }
+        return Region(left=self.left, top=self.top, width=self.width, height=self.height)
 
     @overload
     def __getitem__(self, key: Literal["left", "top", "width", "height"], /) -> int: ...

--- a/src/mss/models.py
+++ b/src/mss/models.py
@@ -3,7 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, overload
+
+
+class CaptureRegion(TypedDict):
+    """Rectangular screen region to capture."""
+
+    left: int
+    top: int
+    width: int
+    height: int
 
 
 @dataclass(frozen=True, slots=True)
@@ -30,6 +39,15 @@ class Monitor:
     name: str | None = None
     unique_id: str | None = None
     output: str | None = None
+
+    def as_capture_region(self) -> CaptureRegion:
+        """Return this monitor's geometry as a capture region."""
+        return {
+            "left": self.left,
+            "top": self.top,
+            "width": self.width,
+            "height": self.height,
+        }
 
     @overload
     def __getitem__(self, key: Literal["left", "top", "width", "height"], /) -> int: ...

--- a/src/mss/models.py
+++ b/src/mss/models.py
@@ -2,11 +2,54 @@
 # Source: https://github.com/BoboTiG/python-mss.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, NamedTuple
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, overload
 
-# TODO @BoboTiG: https://github.com/BoboTiG/python-mss/issues/470
-# Change this to a proper Monitor class in next major release.
-Monitor = dict[str, Any]
+
+@dataclass(frozen=True, slots=True)
+class Monitor:
+    """Monitor geometry and optional platform metadata.
+
+    The optional metadata attributes are:
+
+    - ``is_primary``: whether this is the primary monitor; ``None`` means
+      the platform could not determine it.
+    - ``name``: the human-readable device name; ``None`` means it is
+      unavailable.
+    - ``unique_id``: the platform-specific stable identifier; ``None``
+      means it is unavailable.
+    - ``output``: the Linux output name compatible with xrandr; ``None``
+      means it is unavailable or does not apply to the platform.
+    """
+
+    left: int
+    top: int
+    width: int
+    height: int
+    is_primary: bool | None = None
+    name: str | None = None
+    unique_id: str | None = None
+    output: str | None = None
+
+    @overload
+    def __getitem__(self, key: Literal["left", "top", "width", "height"], /) -> int: ...
+
+    @overload
+    def __getitem__(self, key: Literal["is_primary"], /) -> bool | None: ...
+
+    @overload
+    def __getitem__(self, key: Literal["name", "unique_id", "output"], /) -> str | None: ...
+
+    @overload
+    def __getitem__(self, key: str, /) -> int | bool | str | None: ...
+
+    def __getitem__(self, key: str, /) -> int | bool | str | None:
+        """Provide temporary compatibility with string-key access."""
+        if key not in {"left", "top", "width", "height", "is_primary", "name", "unique_id", "output"}:
+            raise KeyError(key)
+        return getattr(self, key)
+
+
 Monitors = list[Monitor]
 
 Pixel = tuple[int, int, int]

--- a/src/mss/models.py
+++ b/src/mss/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, overload
 
 
-class CaptureRegion(TypedDict):
+class Region(TypedDict):
     """Rectangular screen region to capture."""
 
     left: int
@@ -40,7 +40,7 @@ class Monitor:
     unique_id: str | None = None
     output: str | None = None
 
-    def as_capture_region(self) -> CaptureRegion:
+    def as_region(self) -> Region:
         """Return this monitor's geometry as a capture region."""
         return {
             "left": self.left,

--- a/src/mss/screenshot.py
+++ b/src/mss/screenshot.py
@@ -35,7 +35,7 @@ class ScreenShot:
 
     __slots__ = {"__bgra", "__pixels", "__rgb", "_raw", "pos", "size"}
 
-    def __init__(self, data: Buffer, monitor: Monitor, /, *, size: Size | None = None) -> None:
+    def __init__(self, data: Buffer, monitor: Monitor | dict[str, Any], /, *, size: Size | None = None) -> None:
         self.__pixels: Pixels | None = None
         self.__rgb: memoryview | None = None
 
@@ -84,7 +84,7 @@ class ScreenShot:
     @classmethod
     def from_size(cls: type[ScreenShot], data: Buffer, width: int, height: int, /) -> ScreenShot:
         """Instantiate a new class given only screenshot's data and size."""
-        monitor = {"left": 0, "top": 0, "width": width, "height": height}
+        monitor = Monitor(left=0, top=0, width=width, height=height)
         return cls(data, monitor)
 
     @property

--- a/src/mss/screenshot.py
+++ b/src/mss/screenshot.py
@@ -39,11 +39,21 @@ class ScreenShot:
         self.__pixels: Pixels | None = None
         self.__rgb: memoryview | None = None
 
+        if isinstance(monitor, Monitor):
+            left, top = monitor.left, monitor.top
+        else:  # remove this once we deprecate the string key access
+            left, top = monitor["left"], monitor["top"]
+
         #: NamedTuple of the screenshot coordinates.
-        self.pos: Pos = Pos(monitor["left"], monitor["top"])
+        self.pos: Pos = Pos(left, top)
 
         #: NamedTuple of the screenshot size.
-        self.size: Size = Size(monitor["width"], monitor["height"]) if size is None else size
+        if size is not None:
+            self.size: Size = size
+        elif isinstance(monitor, Monitor):
+            self.size = Size(monitor.width, monitor.height)
+        else:  # remove this once we deprecate the string key access
+            self.size = Size(monitor["width"], monitor["height"])
 
         # Buffer of the raw BGRA pixels, retrieved by the platform-specific implementations.
         self._raw: memoryview[int] = memoryview(data)

--- a/src/mss/screenshot.py
+++ b/src/mss/screenshot.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     import torch
     from typing_extensions import Buffer
 
-    from mss.models import CaptureRegion
+    from mss.models import Region
 
 # Type checkers can see these, but they don't get into the Sphinx docs.  I'm not sure if we should do this differently.
 Channels = Literal["BGRA", "BGR", "RGB", "RGBA"]
@@ -37,7 +37,7 @@ class ScreenShot:
 
     __slots__ = {"__bgra", "__pixels", "__rgb", "_raw", "pos", "size"}
 
-    def __init__(self, data: Buffer, region: CaptureRegion, /, *, size: Size | None = None) -> None:
+    def __init__(self, data: Buffer, region: Region, /, *, size: Size | None = None) -> None:
         self.__pixels: Pixels | None = None
         self.__rgb: memoryview | None = None
 
@@ -89,7 +89,7 @@ class ScreenShot:
     @classmethod
     def from_size(cls: type[ScreenShot], data: Buffer, width: int, height: int, /) -> ScreenShot:
         """Instantiate a new class given only screenshot's data and size."""
-        region: CaptureRegion = {"left": 0, "top": 0, "width": width, "height": height}
+        region: Region = {"left": 0, "top": 0, "width": width, "height": height}
         return cls(data, region)
 
     @property

--- a/src/mss/screenshot.py
+++ b/src/mss/screenshot.py
@@ -7,7 +7,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from mss.exception import ScreenShotError
-from mss.models import Monitor, Pixel, Pixels, Pos, Size
+from mss.models import Pixel, Pixels, Pos, Size
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
     import tensorflow as tf
     import torch
     from typing_extensions import Buffer
+
+    from mss.models import CaptureRegion
 
 # Type checkers can see these, but they don't get into the Sphinx docs.  I'm not sure if we should do this differently.
 Channels = Literal["BGRA", "BGR", "RGB", "RGBA"]
@@ -35,25 +37,18 @@ class ScreenShot:
 
     __slots__ = {"__bgra", "__pixels", "__rgb", "_raw", "pos", "size"}
 
-    def __init__(self, data: Buffer, monitor: Monitor | dict[str, Any], /, *, size: Size | None = None) -> None:
+    def __init__(self, data: Buffer, region: CaptureRegion, /, *, size: Size | None = None) -> None:
         self.__pixels: Pixels | None = None
         self.__rgb: memoryview | None = None
 
-        if isinstance(monitor, Monitor):
-            left, top = monitor.left, monitor.top
-        else:  # remove this once we deprecate the string key access
-            left, top = monitor["left"], monitor["top"]
-
         #: NamedTuple of the screenshot coordinates.
-        self.pos: Pos = Pos(left, top)
+        self.pos: Pos = Pos(region["left"], region["top"])
 
         #: NamedTuple of the screenshot size.
         if size is not None:
             self.size: Size = size
-        elif isinstance(monitor, Monitor):
-            self.size = Size(monitor.width, monitor.height)
-        else:  # remove this once we deprecate the string key access
-            self.size = Size(monitor["width"], monitor["height"])
+        else:
+            self.size = Size(region["width"], region["height"])
 
         # Buffer of the raw BGRA pixels, retrieved by the platform-specific implementations.
         self._raw: memoryview[int] = memoryview(data)
@@ -94,8 +89,8 @@ class ScreenShot:
     @classmethod
     def from_size(cls: type[ScreenShot], data: Buffer, width: int, height: int, /) -> ScreenShot:
         """Instantiate a new class given only screenshot's data and size."""
-        monitor = Monitor(left=0, top=0, width=width, height=height)
-        return cls(data, monitor)
+        region: CaptureRegion = {"left": 0, "top": 0, "width": width, "height": height}
+        return cls(data, region)
 
     @property
     def bgra(self) -> memoryview[int]:

--- a/src/mss/screenshot.py
+++ b/src/mss/screenshot.py
@@ -7,7 +7,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 from mss.exception import ScreenShotError
-from mss.models import Pixel, Pixels, Pos, Size
+from mss.models import Monitor, Pixel, Pixels, Pos, Region, Size
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -19,8 +19,6 @@ if TYPE_CHECKING:
     import tensorflow as tf
     import torch
     from typing_extensions import Buffer
-
-    from mss.models import Region
 
 # Type checkers can see these, but they don't get into the Sphinx docs.  I'm not sure if we should do this differently.
 Channels = Literal["BGRA", "BGR", "RGB", "RGBA"]
@@ -37,18 +35,26 @@ class ScreenShot:
 
     __slots__ = {"__bgra", "__pixels", "__rgb", "_raw", "pos", "size"}
 
-    def __init__(self, data: Buffer, region: Region, /, *, size: Size | None = None) -> None:
+    def __init__(self, data: Buffer, region: Monitor | Region | dict[str, Any], /, *, size: Size | None = None) -> None:
+        if isinstance(region, dict):
+            region = Region(
+                left=region["left"],
+                top=region["top"],
+                width=region["width"],
+                height=region["height"],
+            )
+
         self.__pixels: Pixels | None = None
         self.__rgb: memoryview | None = None
 
         #: NamedTuple of the screenshot coordinates.
-        self.pos: Pos = Pos(region["left"], region["top"])
+        self.pos: Pos = Pos(region.left, region.top)
 
         #: NamedTuple of the screenshot size.
         if size is not None:
             self.size: Size = size
         else:
-            self.size = Size(region["width"], region["height"])
+            self.size = Size(region.width, region.height)
 
         # Buffer of the raw BGRA pixels, retrieved by the platform-specific implementations.
         self._raw: memoryview[int] = memoryview(data)
@@ -89,7 +95,7 @@ class ScreenShot:
     @classmethod
     def from_size(cls: type[ScreenShot], data: Buffer, width: int, height: int, /) -> ScreenShot:
         """Instantiate a new class given only screenshot's data and size."""
-        region: Region = {"left": 0, "top": 0, "width": width, "height": height}
+        region = Region(left=0, top=0, width=width, height=height)
         return cls(data, region)
 
     @property

--- a/src/mss/windows/gdi.py
+++ b/src/mss/windows/gdi.py
@@ -32,12 +32,12 @@ from typing import TYPE_CHECKING
 
 from mss.base import MSSImplementation
 from mss.exception import ScreenShotError
+from mss.models import Monitor
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from typing import Any
 
-    from mss.models import CFunctionsErrChecked, Monitor, Monitors
+    from mss.models import CFunctionsErrChecked, Monitors
 
 __all__ = ()
 
@@ -276,12 +276,12 @@ class MSSImplGdi(MSSImplementation):
 
         # All monitors
         monitors.append(
-            {
-                "left": int_(get_system_metrics(76)),  # SM_XVIRTUALSCREEN
-                "top": int_(get_system_metrics(77)),  # SM_YVIRTUALSCREEN
-                "width": int_(get_system_metrics(78)),  # SM_CXVIRTUALSCREEN
-                "height": int_(get_system_metrics(79)),  # SM_CYVIRTUALSCREEN
-            },
+            Monitor(
+                left=int_(get_system_metrics(76)),  # SM_XVIRTUALSCREEN
+                top=int_(get_system_metrics(77)),  # SM_YVIRTUALSCREEN
+                width=int_(get_system_metrics(78)),  # SM_CXVIRTUALSCREEN
+                height=int_(get_system_metrics(79)),  # SM_CYVIRTUALSCREEN
+            ),
         )
 
         # Each monitor
@@ -323,18 +323,17 @@ class MSSImplGdi(MSSImplementation):
             ):
                 unique_id = ctypes.wstring_at(ctypes.addressof(display_device.DeviceID))
 
-            mon_dict: dict[str, Any] = {
-                "left": left,
-                "top": top,
-                "width": int_(rct.right) - left,
-                "height": int_(rct.bottom) - top,
-                "is_primary": is_primary,
-            }
-            if device_string is not None:
-                mon_dict["name"] = device_string
-            if unique_id is not None:
-                mon_dict["unique_id"] = unique_id
-            monitors.append(mon_dict)
+            monitors.append(
+                Monitor(
+                    left=left,
+                    top=top,
+                    width=int_(rct.right) - left,
+                    height=int_(rct.bottom) - top,
+                    is_primary=is_primary,
+                    name=device_string,
+                    unique_id=unique_id,
+                ),
+            )
             return True
 
         user32.EnumDisplayMonitors(0, None, callback, 0)
@@ -360,7 +359,7 @@ class MSSImplGdi(MSSImplementation):
         try:
             memdc = gdi.CreateCompatibleDC(srcdc)
             try:
-                width, height = monitor["width"], monitor["height"]
+                width, height = monitor.width, monitor.height
 
                 if self._region_width_height != (width, height):
                     self._region_width_height = (width, height)
@@ -392,7 +391,7 @@ class MSSImplGdi(MSSImplementation):
                 gdi.SelectObject(memdc, self._dib)
 
                 # BitBlt copies screen content directly into the DIB's memory
-                gdi.BitBlt(memdc, 0, 0, width, height, srcdc, monitor["left"], monitor["top"], SRCCOPY | CAPTUREBLT)
+                gdi.BitBlt(memdc, 0, 0, width, height, srcdc, monitor.left, monitor.top, SRCCOPY | CAPTUREBLT)
 
                 # Flush GDI operations to ensure DIB memory is fully updated before reading.
                 gdi.GdiFlush()

--- a/src/mss/windows/gdi.py
+++ b/src/mss/windows/gdi.py
@@ -37,7 +37,7 @@ from mss.models import Monitor
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from mss.models import CaptureRegion, CFunctionsErrChecked, Monitors
+    from mss.models import CFunctionsErrChecked, Monitors, Region
 
 __all__ = ()
 
@@ -340,7 +340,7 @@ class MSSImplGdi(MSSImplementation):
 
         return monitors
 
-    def grab(self, region: CaptureRegion, /) -> bytearray:
+    def grab(self, region: Region, /) -> bytearray:
         """Retrieve all pixels from a capture region using CreateDIBSection.
 
         Device contexts (srcdc / memdc) are acquired and released within each

--- a/src/mss/windows/gdi.py
+++ b/src/mss/windows/gdi.py
@@ -37,7 +37,7 @@ from mss.models import Monitor
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from mss.models import CFunctionsErrChecked, Monitors
+    from mss.models import CaptureRegion, CFunctionsErrChecked, Monitors
 
 __all__ = ()
 
@@ -340,8 +340,8 @@ class MSSImplGdi(MSSImplementation):
 
         return monitors
 
-    def grab(self, monitor: Monitor, /) -> bytearray:
-        """Retrieve all pixels from a monitor using CreateDIBSection.
+    def grab(self, region: CaptureRegion, /) -> bytearray:
+        """Retrieve all pixels from a capture region using CreateDIBSection.
 
         Device contexts (srcdc / memdc) are acquired and released within each
         call.  This avoids holding GDI resources across threads and allows
@@ -359,7 +359,7 @@ class MSSImplGdi(MSSImplementation):
         try:
             memdc = gdi.CreateCompatibleDC(srcdc)
             try:
-                width, height = monitor.width, monitor.height
+                width, height = region["width"], region["height"]
 
                 if self._region_width_height != (width, height):
                     self._region_width_height = (width, height)
@@ -391,7 +391,17 @@ class MSSImplGdi(MSSImplementation):
                 gdi.SelectObject(memdc, self._dib)
 
                 # BitBlt copies screen content directly into the DIB's memory
-                gdi.BitBlt(memdc, 0, 0, width, height, srcdc, monitor.left, monitor.top, SRCCOPY | CAPTUREBLT)
+                gdi.BitBlt(
+                    memdc,
+                    0,
+                    0,
+                    width,
+                    height,
+                    srcdc,
+                    region["left"],
+                    region["top"],
+                    SRCCOPY | CAPTUREBLT,
+                )
 
                 # Flush GDI operations to ensure DIB memory is fully updated before reading.
                 gdi.GdiFlush()

--- a/src/mss/windows/gdi.py
+++ b/src/mss/windows/gdi.py
@@ -359,7 +359,7 @@ class MSSImplGdi(MSSImplementation):
         try:
             memdc = gdi.CreateCompatibleDC(srcdc)
             try:
-                width, height = region["width"], region["height"]
+                width, height = region.width, region.height
 
                 if self._region_width_height != (width, height):
                     self._region_width_height = (width, height)
@@ -398,8 +398,8 @@ class MSSImplGdi(MSSImplementation):
                     width,
                     height,
                     srcdc,
-                    region["left"],
-                    region["top"],
+                    region.left,
+                    region.top,
                     SRCCOPY | CAPTUREBLT,
                 )
 

--- a/src/tests/bench_grab_windows.py
+++ b/src/tests/bench_grab_windows.py
@@ -26,7 +26,7 @@ def benchmark_grab() -> tuple[float, float]:
     """
     with mss.MSS() as sct:
         monitor = sct.monitors[1]  # Primary monitor
-        width, height = monitor["width"], monitor["height"]
+        width, height = monitor.width, monitor.height
 
         print(f"Platform: {sys.platform}")
         print(f"Region: {width}x{height}")
@@ -113,8 +113,8 @@ def benchmark_raw_bitblt() -> None:
 
     with mss.MSS() as sct:
         monitor = sct.monitors[1]
-        width, height = monitor["width"], monitor["height"]
-        left, top = monitor["left"], monitor["top"]
+        width, height = monitor.width, monitor.height
+        left, top = monitor.left, monitor.top
 
         # Acquire DCs directly for raw benchmarking (the impl no longer
         # holds them as instance state — they are per-grab now).
@@ -151,7 +151,7 @@ def analyze_frame_timing() -> None:
 
     with mss.MSS() as sct:
         monitor = sct.monitors[1]
-        width, height = monitor["width"], monitor["height"]
+        width, height = monitor.width, monitor.height
 
         print("Frame timing analysis")
         print(f"Region: {width}x{height}")

--- a/src/tests/test_cls_image.py
+++ b/src/tests/test_cls_image.py
@@ -22,4 +22,5 @@ def test_custom_cls_image(mss_impl: Callable[..., MSS]) -> None:
         image = sct.grab(mon1)
     assert isinstance(image, SimpleScreenShot)
     assert isinstance(image.raw, bytes)
+    assert isinstance(image.region, Region)
     assert image.region == mon1.as_region()

--- a/src/tests/test_cls_image.py
+++ b/src/tests/test_cls_image.py
@@ -6,11 +6,11 @@ from collections.abc import Callable
 from typing import Any
 
 from mss import MSS
-from mss.models import CaptureRegion
+from mss.models import Region
 
 
 class SimpleScreenShot:
-    def __init__(self, data: bytearray, region: CaptureRegion, **_: Any) -> None:
+    def __init__(self, data: bytearray, region: Region, **_: Any) -> None:
         self.raw = bytes(data)
         self.region = region
 
@@ -22,4 +22,4 @@ def test_custom_cls_image(mss_impl: Callable[..., MSS]) -> None:
         image = sct.grab(mon1)
     assert isinstance(image, SimpleScreenShot)
     assert isinstance(image.raw, bytes)
-    assert image.region == mon1.as_capture_region()
+    assert image.region == mon1.as_region()

--- a/src/tests/test_cls_image.py
+++ b/src/tests/test_cls_image.py
@@ -22,4 +22,4 @@ def test_custom_cls_image(mss_impl: Callable[..., MSS]) -> None:
         image = sct.grab(mon1)
     assert isinstance(image, SimpleScreenShot)
     assert isinstance(image.raw, bytes)
-    assert isinstance(image.monitor, dict)
+    assert isinstance(image.monitor, Monitor)

--- a/src/tests/test_cls_image.py
+++ b/src/tests/test_cls_image.py
@@ -15,12 +15,16 @@ class SimpleScreenShot:
         self.region = region
 
 
-def test_custom_cls_image(mss_impl: Callable[..., MSS]) -> None:
+def test_custom_cls_image_receives_region_snapshot(mss_impl: Callable[..., MSS]) -> None:
     with mss_impl() as sct:
         sct.cls_image = SimpleScreenShot  # type: ignore[assignment]
-        mon1 = sct.monitors[1]
-        image = sct.grab(mon1)
+        region = sct.monitors[1].as_region()
+        image = sct.grab(region)
     assert isinstance(image, SimpleScreenShot)
     assert isinstance(image.raw, bytes)
     assert isinstance(image.region, Region)
-    assert image.region == mon1.as_region()
+    assert image.region == region
+    assert image.region is not region
+
+    region.width -= 1
+    assert image.region.width != region.width

--- a/src/tests/test_cls_image.py
+++ b/src/tests/test_cls_image.py
@@ -6,13 +6,13 @@ from collections.abc import Callable
 from typing import Any
 
 from mss import MSS
-from mss.models import Monitor
+from mss.models import CaptureRegion
 
 
 class SimpleScreenShot:
-    def __init__(self, data: bytearray, monitor: Monitor, **_: Any) -> None:
+    def __init__(self, data: bytearray, region: CaptureRegion, **_: Any) -> None:
         self.raw = bytes(data)
-        self.monitor = monitor
+        self.region = region
 
 
 def test_custom_cls_image(mss_impl: Callable[..., MSS]) -> None:
@@ -22,4 +22,4 @@ def test_custom_cls_image(mss_impl: Callable[..., MSS]) -> None:
         image = sct.grab(mon1)
     assert isinstance(image, SimpleScreenShot)
     assert isinstance(image.raw, bytes)
-    assert isinstance(image.monitor, Monitor)
+    assert image.region == mon1.as_capture_region()

--- a/src/tests/test_find_monitors.py
+++ b/src/tests/test_find_monitors.py
@@ -5,33 +5,35 @@ Source: https://github.com/BoboTiG/python-mss.
 from collections.abc import Callable
 
 from mss import MSS
+from mss.models import Monitor
 
 
 def test_get_monitors(mss_impl: Callable[..., MSS]) -> None:
     with mss_impl() as sct:
         assert sct.monitors
+        assert all(isinstance(monitor, Monitor) for monitor in sct.monitors)
 
 
-def test_keys_aio(mss_impl: Callable[..., MSS]) -> None:
+def test_geometry_aio(mss_impl: Callable[..., MSS]) -> None:
     with mss_impl() as sct:
         all_monitors = sct.monitors[0]
-    assert "top" in all_monitors
-    assert "left" in all_monitors
-    assert "height" in all_monitors
-    assert "width" in all_monitors
+    assert isinstance(all_monitors.top, int)
+    assert isinstance(all_monitors.left, int)
+    assert isinstance(all_monitors.height, int)
+    assert isinstance(all_monitors.width, int)
 
 
-def test_keys_monitor_1(mss_impl: Callable[..., MSS]) -> None:
+def test_geometry_monitor_1(mss_impl: Callable[..., MSS]) -> None:
     with mss_impl() as sct:
         mon1 = sct.monitors[1]
-    assert "top" in mon1
-    assert "left" in mon1
-    assert "height" in mon1
-    assert "width" in mon1
+    assert isinstance(mon1.top, int)
+    assert isinstance(mon1.left, int)
+    assert isinstance(mon1.height, int)
+    assert isinstance(mon1.width, int)
 
 
 def test_dimensions(mss_impl: Callable[..., MSS]) -> None:
     with mss_impl() as sct:
         mon = sct.monitors[1]
-    assert mon["width"] > 0
-    assert mon["height"] > 0
+    assert mon.width > 0
+    assert mon.height > 0

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -206,7 +206,15 @@ class TestEntryPoint:
                     zip(sct.monitors[1:], captured.out.splitlines(), strict=False),
                     1,
                 ):
-                    filename = Path(fmt.format(mon=mon, **monitor))
+                    filename = Path(
+                        fmt.format(
+                            mon=mon,
+                            top=monitor.top,
+                            left=monitor.left,
+                            width=monitor.width,
+                            height=monitor.height,
+                        ),
+                    )
                     assert line.endswith(filename.name)
                     assert filename.is_file()
                     filename.unlink()
@@ -370,8 +378,8 @@ def test_grab_with_invalid_tuple(mss_impl: Callable[..., MSS]) -> None:
 def test_grab_with_tuple_percents(mss_impl: Callable[..., MSS]) -> None:
     with mss_impl() as sct:
         monitor = sct.monitors[1]
-        left = monitor["left"] + monitor["width"] * 5 // 100  # 5% from the left
-        top = monitor["top"] + monitor["height"] * 5 // 100  # 5% from the top
+        left = monitor.left + monitor.width * 5 // 100  # 5% from the left
+        top = monitor.top + monitor.height * 5 // 100  # 5% from the top
         right = left + 500  # 500px
         lower = top + 500  # 500px
         width = right - left

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -20,6 +20,7 @@ from mss.__main__ import _parse_coordinates
 from mss.__main__ import main as entry_point
 from mss.base import MSS, MSSImplementation
 from mss.exception import ScreenShotError
+from mss.models import Monitor, Region
 from mss.screenshot import ScreenShot
 from tests.thread_helpers import run_threads
 
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
 
-    from mss.models import Monitors, Region, Size
+    from mss.models import Monitors, Size
 
 try:
     from datetime import UTC
@@ -119,11 +120,29 @@ def test_bad_monitor(mss_impl: Callable[..., MSS]) -> None:
 
 def test_repr(mss_impl: Callable[..., MSS]) -> None:
     box = {"top": 0, "left": 0, "width": 10, "height": 10}
-    expected_box: Region = {"top": 0, "left": 0, "width": 10, "height": 10}
+    expected_region = Region(top=0, left=0, width=10, height=10)
     with mss_impl() as sct:
         img = sct.grab(box)
-    ref = ScreenShot(bytearray(b"BGRA" * 100), expected_box)
+    ref = ScreenShot(bytearray(b"BGRA" * 100), expected_region)
     assert repr(img) == repr(ref)
+
+
+def test_screenshot_accepts_region_dictionary() -> None:
+    region = {"top": 0, "left": 0, "width": 10, "height": 10}
+
+    screenshot = ScreenShot(bytearray(b"BGRA" * 100), region)
+
+    assert screenshot.pos == (0, 0)
+    assert screenshot.size == (10, 10)
+
+
+def test_screenshot_accepts_monitor() -> None:
+    monitor = Monitor(left=0, top=0, width=10, height=10)
+
+    screenshot = ScreenShot(bytearray(b"BGRA" * 100), monitor)
+
+    assert screenshot.pos == (0, 0)
+    assert screenshot.size == (10, 10)
 
 
 def test_factory_no_backend() -> None:
@@ -356,6 +375,13 @@ def test_grab_with_tuple(mss_impl: Callable[..., MSS]) -> None:
         assert im.size == im2.size
         assert im.pos == im2.pos
         assert im.rgb == im2.rgb
+
+        # Region object
+        region = Region(left=left, top=top, width=width, height=height)
+        im3 = sct.grab(region)
+        assert im.size == im3.size
+        assert im.pos == im3.pos
+        assert im.rgb == im3.rgb
 
 
 def test_grab_with_invalid_tuple(mss_impl: Callable[..., MSS]) -> None:

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
 
-    from mss.models import Monitor, Monitors, Size
+    from mss.models import CaptureRegion, Monitors, Size
 
 try:
     from datetime import UTC
@@ -45,7 +45,7 @@ class MSS0(MSSImplementation):
 class MSS1(MSSImplementation):
     """Only `grab()` implemented."""
 
-    def grab(self, monitor: Monitor) -> None:  # type: ignore[override]
+    def grab(self, region: CaptureRegion) -> None:  # type: ignore[override]
         pass
 
 
@@ -66,7 +66,7 @@ class MSSCloseRaises(MSSImplementation):
     def cursor(self) -> None:
         pass
 
-    def grab(self, _: Monitor) -> bytearray | tuple[bytearray, Size]:
+    def grab(self, _: CaptureRegion) -> bytearray | tuple[bytearray, Size]:
         return bytearray()
 
     def monitors(self) -> Monitors:
@@ -119,7 +119,7 @@ def test_bad_monitor(mss_impl: Callable[..., MSS]) -> None:
 
 def test_repr(mss_impl: Callable[..., MSS]) -> None:
     box = {"top": 0, "left": 0, "width": 10, "height": 10}
-    expected_box = {"top": 0, "left": 0, "width": 10, "height": 10}
+    expected_box: CaptureRegion = {"top": 0, "left": 0, "width": 10, "height": 10}
     with mss_impl() as sct:
         img = sct.grab(box)
     ref = ScreenShot(bytearray(b"BGRA" * 100), expected_box)

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
 
-    from mss.models import CaptureRegion, Monitors, Size
+    from mss.models import Monitors, Region, Size
 
 try:
     from datetime import UTC
@@ -45,7 +45,7 @@ class MSS0(MSSImplementation):
 class MSS1(MSSImplementation):
     """Only `grab()` implemented."""
 
-    def grab(self, region: CaptureRegion) -> None:  # type: ignore[override]
+    def grab(self, region: Region) -> None:  # type: ignore[override]
         pass
 
 
@@ -66,7 +66,7 @@ class MSSCloseRaises(MSSImplementation):
     def cursor(self) -> None:
         pass
 
-    def grab(self, _: CaptureRegion) -> bytearray | tuple[bytearray, Size]:
+    def grab(self, _: Region) -> bytearray | tuple[bytearray, Size]:
         return bytearray()
 
     def monitors(self) -> Monitors:
@@ -119,7 +119,7 @@ def test_bad_monitor(mss_impl: Callable[..., MSS]) -> None:
 
 def test_repr(mss_impl: Callable[..., MSS]) -> None:
     box = {"top": 0, "left": 0, "width": 10, "height": 10}
-    expected_box: CaptureRegion = {"top": 0, "left": 0, "width": 10, "height": 10}
+    expected_box: Region = {"top": 0, "left": 0, "width": 10, "height": 10}
     with mss_impl() as sct:
         img = sct.grab(box)
     ref = ScreenShot(bytearray(b"BGRA" * 100), expected_box)

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -376,12 +376,21 @@ def test_grab_with_tuple(mss_impl: Callable[..., MSS]) -> None:
         assert im.pos == im2.pos
         assert im.rgb == im2.rgb
 
-        # Region object
+
+def test_grab_with_region(mss_impl: Callable[..., MSS]) -> None:
+    left = 100
+    top = 100
+    width = 400
+    height = 400
+
+    with mss_impl() as sct:
+        expected = sct.grab({"left": left, "top": top, "width": width, "height": height})
         region = Region(left=left, top=top, width=width, height=height)
-        im3 = sct.grab(region)
-        assert im.size == im3.size
-        assert im.pos == im3.pos
-        assert im.rgb == im3.rgb
+        image = sct.grab(region)
+
+    assert image.size == expected.size
+    assert image.pos == expected.pos
+    assert image.rgb == expected.rgb
 
 
 def test_grab_with_invalid_tuple(mss_impl: Callable[..., MSS]) -> None:

--- a/src/tests/test_macos.py
+++ b/src/tests/test_macos.py
@@ -60,8 +60,8 @@ def test_implementation(monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(sct._impl.core, "CGDisplayRotation", lambda _: -90.0)
         sct._monitors = None
         modified = sct.monitors[1]
-        assert original["width"] == modified["height"]
-        assert original["height"] == modified["width"]
+        assert original.width == modified.height
+        assert original.height == modified.width
         monkeypatch.undo()
 
         # Test bad data retrieval

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -5,7 +5,22 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
-from mss.models import Monitor
+from mss.models import Monitor, Region
+
+
+def test_region() -> None:
+    region = Region(left=1, top=2, width=3, height=4)
+
+    assert (region.left, region.top, region.width, region.height) == (1, 2, 3, 4)
+    assert not isinstance(region, Mapping)
+    assert not hasattr(region, "__dict__")
+
+    region.left = 5
+    region.top = 6
+    region.width = 7
+    region.height = 8
+
+    assert (region.left, region.top, region.width, region.height) == (5, 6, 7, 8)
 
 
 def test_monitor() -> None:
@@ -25,7 +40,7 @@ def test_monitor() -> None:
     assert monitor.name == "Display"
     assert monitor.unique_id == "display-id"
     assert monitor.output == "DP-1"
-    assert monitor.as_region() == {"left": 1, "top": 2, "width": 3, "height": 4}
+    assert monitor.as_region() == Region(left=1, top=2, width=3, height=4)
     assert not isinstance(monitor, Mapping)
     assert not hasattr(monitor, "__dict__")
 

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -29,7 +29,7 @@ def test_monitor() -> None:
     assert not hasattr(monitor, "__dict__")
 
     with pytest.raises(FrozenInstanceError):
-        monitor.width = 5
+        monitor.width = 5  # type: ignore[misc]
 
 
 def test_monitor_string_key_access() -> None:

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -25,6 +25,7 @@ def test_monitor() -> None:
     assert monitor.name == "Display"
     assert monitor.unique_id == "display-id"
     assert monitor.output == "DP-1"
+    assert monitor.as_capture_region() == {"left": 1, "top": 2, "width": 3, "height": 4}
     assert not isinstance(monitor, Mapping)
     assert not hasattr(monitor, "__dict__")
 

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -1,0 +1,66 @@
+"""Tests for public data models."""
+
+from collections.abc import Mapping
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from mss.models import Monitor
+
+
+def test_monitor() -> None:
+    monitor = Monitor(
+        left=1,
+        top=2,
+        width=3,
+        height=4,
+        is_primary=True,
+        name="Display",
+        unique_id="display-id",
+        output="DP-1",
+    )
+
+    assert (monitor.left, monitor.top, monitor.width, monitor.height) == (1, 2, 3, 4)
+    assert monitor.is_primary is True
+    assert monitor.name == "Display"
+    assert monitor.unique_id == "display-id"
+    assert monitor.output == "DP-1"
+    assert not isinstance(monitor, Mapping)
+    assert not hasattr(monitor, "__dict__")
+
+    with pytest.raises(FrozenInstanceError):
+        monitor.width = 5
+
+
+def test_monitor_string_key_access() -> None:
+    monitor = Monitor(
+        left=1,
+        top=2,
+        width=3,
+        height=4,
+        is_primary=True,
+        name="Display",
+        unique_id="display-id",
+        output="DP-1",
+    )
+
+    assert monitor["left"] == monitor.left
+    assert monitor["top"] == monitor.top
+    assert monitor["width"] == monitor.width
+    assert monitor["height"] == monitor.height
+    assert monitor["is_primary"] == monitor.is_primary
+    assert monitor["name"] == monitor.name
+    assert monitor["unique_id"] == monitor.unique_id
+    assert monitor["output"] == monitor.output
+
+    with pytest.raises(KeyError):
+        monitor["unknown"]
+
+
+def test_monitor_optional_metadata_defaults_to_none() -> None:
+    monitor = Monitor(left=1, top=2, width=3, height=4)
+
+    assert monitor.is_primary is None
+    assert monitor.name is None
+    assert monitor.unique_id is None
+    assert monitor.output is None

--- a/src/tests/test_models.py
+++ b/src/tests/test_models.py
@@ -25,7 +25,7 @@ def test_monitor() -> None:
     assert monitor.name == "Display"
     assert monitor.unique_id == "display-id"
     assert monitor.output == "DP-1"
-    assert monitor.as_capture_region() == {"left": 1, "top": 2, "width": 3, "height": 4}
+    assert monitor.as_region() == {"left": 1, "top": 2, "width": 3, "height": 4}
     assert not isinstance(monitor, Mapping)
     assert not hasattr(monitor, "__dict__")
 

--- a/src/tests/test_primary_monitor.py
+++ b/src/tests/test_primary_monitor.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 import pytest
 
 from mss import MSS
+from mss.models import Monitor
 
 
 def test_primary_monitor(mss_impl: Callable[..., MSS]) -> None:
@@ -16,19 +17,14 @@ def test_primary_monitor(mss_impl: Callable[..., MSS]) -> None:
         primary = sct.primary_monitor
         monitors = sct.monitors
 
-        # Should return a valid monitor dict
-        assert isinstance(primary, dict)
-        assert "left" in primary
-        assert "top" in primary
-        assert "width" in primary
-        assert "height" in primary
+        assert isinstance(primary, Monitor)
 
         # Should be in the monitors list (excluding index 0 which is "all monitors")
         assert primary in monitors[1:]
 
         # Should either be marked as primary or be the first monitor as fallback
-        if primary.get("is_primary", False):
-            assert primary["is_primary"] is True
+        if primary.is_primary:
+            assert primary.is_primary is True
         else:
             assert primary == monitors[1]
 
@@ -40,7 +36,7 @@ def test_primary_monitor_coordinates_windows() -> None:
 
     with mss.MSS() as sct:
         primary = sct.primary_monitor
-        if primary.get("is_primary", False):
+        if primary.is_primary:
             # On Windows, the primary monitor is at (0, 0)
-            assert primary["left"] == 0
-            assert primary["top"] == 0
+            assert primary.left == 0
+            assert primary.top == 0

--- a/src/tests/test_save.py
+++ b/src/tests/test_save.py
@@ -60,8 +60,34 @@ def test_output_format_positions_and_sizes(mss_impl: Callable[..., MSS]) -> None
     fmt = "sct-{top}x{left}_{width}x{height}.png"
     with mss_impl() as sct:
         filename = sct.shot(mon=1, output=fmt)
-        assert filename == fmt.format(**sct.monitors[1])
+        monitor = sct.monitors[1]
+        assert filename == fmt.format(
+            top=monitor.top,
+            left=monitor.left,
+            width=monitor.width,
+            height=monitor.height,
+        )
     assert Path(filename).is_file()
+
+
+def test_output_format_optional(mss_impl: Callable[..., MSS]) -> None:
+    class FormattingCompleteError(Exception):
+        pass
+
+    filename = ""
+
+    def capture_filename(value: str) -> None:
+        nonlocal filename
+        filename = value
+        raise FormattingCompleteError
+
+    fmt = "sct-{is_primary}-{unique_id}.png"
+    with mss_impl() as sct:
+        monitor = sct.monitors[1]
+        with pytest.raises(FormattingCompleteError):
+            next(sct.save(mon=1, output=fmt, callback=capture_filename))
+
+    assert filename == fmt.format(is_primary=monitor.is_primary, unique_id=monitor.unique_id)
 
 
 def test_output_format_date_simple(mss_impl: Callable[..., MSS]) -> None:

--- a/src/tests/test_setup.py
+++ b/src/tests/test_setup.py
@@ -106,6 +106,7 @@ def test_sdist() -> None:
         f"mss-{__version__}/src/tests/test_issue_220.py",
         f"mss-{__version__}/src/tests/test_leaks.py",
         f"mss-{__version__}/src/tests/test_macos.py",
+        f"mss-{__version__}/src/tests/test_models.py",
         f"mss-{__version__}/src/tests/test_primary_monitor.py",
         f"mss-{__version__}/src/tests/test_save.py",
         f"mss-{__version__}/src/tests/test_setup.py",

--- a/src/tests/test_windows.py
+++ b/src/tests/test_windows.py
@@ -163,7 +163,7 @@ def test_monitors_work_when_getwindowdc_fails() -> None:
         try:
             monitors = sct.monitors
             assert len(monitors) >= 1
-            assert "width" in monitors[0]
+            assert monitors[0].width > 0
 
             with pytest.raises(ScreenShotError):
                 sct.grab(monitors[1])


### PR DESCRIPTION
### Changes proposed in this PR

Fixes #470

Replace heterogeneous monitor dictionaries with a frozen, slotted `Monitor` dataclass that exposes typed geometry and
platform metadata attributes.

- Update the macOS, GNU/Linux, and Windows backends to produce and consume `Monitor` objects.
- Keep temporary string-key access for migration, while continuing to accept dictionaries and PIL-style tuples in
  `grab()`.
- Introduce new `Region` class and `as_region` factory function for Monitors; refactor code to use these
- Preserve immutable monitor descriptions in the video demos by constructing separate ojbects for cropped capture
  regions.
- Update filename formatting, examples, documentation, release notes, typing, and tests for the new model.
- Update AGENTS.md with instructions on how to update `test_sdist` when files are added, removed, or renamed.

This gives callers a stable, read-only monitor representation without preventing existing applications from passing
dictionary-based capture regions.

- [x] Tests added/updated
- [x] Documentation updated
- [x] Changelog entry added
- [x] `./check.sh` passed

Validation: `uv run ./check.sh`. The full pytest suite was not run during the final review.

### AI assistance disclosure

- [x] AI assistance was used to generate this contribution.

Codex assisted with reviewing the implementation, identifying and implementing follow-up fixes in the demos and
`ScreenShot` initialization, updating the immutability test for static typing, running validation, and drafting this PR
description. The contributor reviewed and directed the API and capture-region decisions.
