### PR TITLE
Fix X-style geometry parsing

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -297,9 +297,7 @@ Or via direct call from Python::
     -h, --help            show this help message and exit
     -c, --coordinates COORDINATES
                           the part of the screen to capture:
-                          TOP,LEFT,WIDTH,HEIGHT or WIDTHxHEIGHT+LEFT+TOP;
-                          negative TOP or LEFT are insets from the bottom or
-                          right edge
+                          TOP,LEFT,WIDTH,HEIGHT or WIDTHxHEIGHT+LEFT+TOP
     -l, --level {0,1,2,3,4,5,6,7,8,9}
                           the PNG compression level
     -m, --monitor MONITOR
@@ -322,5 +320,4 @@ Or via direct call from Python::
     ``--backend`` to force selecting the backend to use.
 
 .. versionadded:: 11.0.0
-    ``--coordinates`` now accepts coordinates in the traditional X11 style (WIDTHxHEIGHT+LEFT+TOP), as well as negative
-    left or top values (in either style).
+    ``--coordinates`` now accepts coordinates in the traditional X11 style (WIDTHxHEIGHT+LEFT+TOP).

--- a/src/mss/__main__.py
+++ b/src/mss/__main__.py
@@ -10,8 +10,8 @@ from argparse import ArgumentError, ArgumentParser, Namespace
 from typing import Any, NamedTuple
 
 from mss import MSS, __version__
-from mss.models import Monitor
 from mss.exception import ScreenShotError
+from mss.models import Monitor
 from mss.tools import to_png
 
 _COORDINATES_SYNTAX = "TOP,LEFT,WIDTH,HEIGHT or WIDTHxHEIGHT+LEFT+TOP"
@@ -196,7 +196,7 @@ def _prepare_grab_options(options: Namespace) -> tuple[int, str, _CoordsWithEdge
     """Build grab options derived from parsed CLI arguments."""
     monitor_index = int(options.monitor)
     output_template = str(options.output)
-    if options.coordinates is None:
+    if not options.coordinates:
         return monitor_index, output_template, None
 
     coordinates = _parse_coordinates(str(options.coordinates))
@@ -214,10 +214,6 @@ def _build_mss_kwargs(options: Namespace) -> dict[str, Any]:
 
 
 def _normalize_capture_region(coordinates: _CoordsWithEdges, reference: Monitor, bounds: Monitor) -> Monitor:
-    print(coordinates)
-    print(reference)
-    print(bounds)
-
     if coordinates.from_bottom:
         top = reference["top"] + reference["height"] - coordinates.top - coordinates.height
     else:
@@ -235,14 +231,12 @@ def _normalize_capture_region(coordinates: _CoordsWithEdges, reference: Monitor,
     top = max(top, bounds["top"])
     left = max(left, bounds["left"])
 
-    rv = {
+    return {
         "top": top,
         "left": left,
         "height": bottom - top,
         "width": right - left,
     }
-    print(rv)
-    return rv
 
 
 def _capture_and_save(
@@ -255,8 +249,6 @@ def _capture_and_save(
 ) -> None:
     """Capture screenshots and write output files."""
     if coordinates is not None:
-        desktop = sct.monitors[0]
-        mon = sct.monitors[monitor_index]
         capture_region = _normalize_capture_region(coordinates, sct.monitors[monitor_index], sct.monitors[0])
         output = output_template.format(**capture_region)
         sct_img = sct.grab(capture_region)

--- a/src/mss/__main__.py
+++ b/src/mss/__main__.py
@@ -213,7 +213,7 @@ def _build_mss_kwargs(options: Namespace) -> dict[str, Any]:
     return mss_kwargs
 
 
-def _normalize_capture_region(coordinates: _CoordsWithEdges, reference: Monitor, bounds: Monitor) -> Monitor:
+def _normalize_capture_region(coordinates: _CoordsWithEdges, reference: Monitor) -> Monitor:
     if coordinates.from_bottom:
         top = reference["top"] + reference["height"] - coordinates.top - coordinates.height
     else:
@@ -223,20 +223,7 @@ def _normalize_capture_region(coordinates: _CoordsWithEdges, reference: Monitor,
     else:
         left = reference["left"] + coordinates.left
 
-    # It's easier to crop to the bounds if we work on bottom and right.
-    bounds_bottom = bounds["top"] + bounds["height"]
-    bounds_right = bounds["left"] + bounds["width"]
-    bottom = min(top + coordinates.height, bounds_bottom)
-    right = min(left + coordinates.width, bounds_right)
-    top = max(top, bounds["top"])
-    left = max(left, bounds["left"])
-
-    return {
-        "top": top,
-        "left": left,
-        "height": bottom - top,
-        "width": right - left,
-    }
+    return {"top": top, "left": left, "height": coordinates.height, "width": coordinates.width}
 
 
 def _capture_and_save(
@@ -249,7 +236,7 @@ def _capture_and_save(
 ) -> None:
     """Capture screenshots and write output files."""
     if coordinates is not None:
-        capture_region = _normalize_capture_region(coordinates, sct.monitors[monitor_index], sct.monitors[0])
+        capture_region = _normalize_capture_region(coordinates, sct.monitors[monitor_index])
         output = output_template.format(**capture_region)
         sct_img = sct.grab(capture_region)
         to_png(sct_img.rgb, sct_img.size, level=options.level, output=output)

--- a/src/mss/__main__.py
+++ b/src/mss/__main__.py
@@ -7,13 +7,23 @@ import platform
 import re
 import sys
 from argparse import ArgumentError, ArgumentParser, Namespace
-from typing import Any
+from typing import Any, NamedTuple
 
 from mss import MSS, __version__
+from mss.models import Monitor
 from mss.exception import ScreenShotError
 from mss.tools import to_png
 
 _COORDINATES_SYNTAX = "TOP,LEFT,WIDTH,HEIGHT or WIDTHxHEIGHT+LEFT+TOP"
+
+
+class _CoordsWithEdges(NamedTuple):
+    top: int
+    left: int
+    width: int
+    height: int
+    from_bottom: bool
+    from_right: bool
 
 
 def _backend_cli_choices() -> list[str]:
@@ -33,14 +43,69 @@ def _backend_cli_choices() -> list[str]:
     return ["default"]
 
 
-def _parse_coordinates(coordinates: str) -> tuple[int, int, int, int]:
+def _parse_xgeom_coordinate(sign1: str, sign2: str | None, magnitude: str) -> tuple[int, bool]:
+    """Parse a TOP or LEFT coordinate of an X-style geometry.
+
+    As in XParseGeometry, the LEFT and/or TOP coordinates may be
+    preceded by ``-`` instead of ``+``.  This means that they should
+    be interpreted as offsets from the bottom or right, rather than
+    the top or left.
+
+    Additionally, the values themselves may be negative.  On X, this
+    normally indicates that they may be partially off-screen.  On
+    Windows and macOS, these are normal coordinates, since those
+    systems always place the primary monitor at 0,0.
+
+    When using values from the bottom or right, the height or width
+    should be added by the caller as additional offsets.  In other
+    words, a region with a width of 100 pixels, with a 25-pixel offset
+    from the right, should still have all 100 onscreen pixels
+    onscreen, with 25 pixels between the region and the right edge of
+    the screen.
+
+    Examples for the TOP coordinate (these are exhaustive):
+    - ``+25`` or ``++25``: 25 pixels from the top
+    - ``-25`` or ``-+25``: 25 pixels from the bottom
+    - ``+-25``: 25 pixels extend above the top
+    - ``--25``: 25 pixels extend below the bottom
+
+    The returned int is negative if the edge is meant to be offscreen,
+    and the returned bool is True if the edge is meant to be from the
+    opposite border.
+    """
+    assert sign1 in {"+", "-"}  # noqa: S101
+    assert sign2 in {"+", "-", None}  # noqa: S101
+    assert "+" not in magnitude  # noqa: S101
+    assert "-" not in magnitude  # noqa: S101
+
+    signs = sign1 if sign2 is None else sign1 + sign2
+
+    magnitude_value = int(magnitude)
+    if signs in {"+", "++"}:
+        return magnitude_value, False
+    if signs in {"-", "-+"}:
+        return magnitude_value, True
+    if signs == "+-":
+        return -magnitude_value, False
+    if signs == "--":
+        return -magnitude_value, True
+    # This is an internal error.
+    msg = "Invalid signs"
+    raise ValueError(msg)
+
+
+def _parse_coordinates(coordinates: str) -> _CoordsWithEdges:
     """Parse a capture region string.
 
     Supports ``TOP,LEFT,WIDTH,HEIGHT`` and X11 geometry style
-    ``WIDTHxHEIGHT+LEFT+TOP`` (with optional ``-`` offsets).
+    ``WIDTHxHEIGHT+LEFT+TOP`` (with optional ``-`` special handling).
+
+    See _parse_xgeom_coordinate for notes about how negative values and
+    the
 
     :param coordinates: Region string to parse.
-    :returns: Parsed coordinates as ``(top, left, width, height)``.
+    :returns: Parsed coordinates as
+        ``(top, left, width, height, from_bottom, from_right)``.
     :raises ValueError: If *coordinates* does not match a supported
         syntax.
     """
@@ -54,25 +119,38 @@ def _parse_coordinates(coordinates: str) -> tuple[int, int, int, int]:
         |
         (?: # WIDTHxHEIGHT+XOFF+YOFF (X11 geometry style; see X(7))
            (?P<width2>[0-9]+)\s*x\s*
-           (?P<height2>[0-9]+)\s*(?P<left2sign>[+-])\s*
-           (?P<left2>[0-9]+)\s*(?P<top2sign>[+-])\s*
-           (?P<top2>[0-9]+))
+           (?P<height2>[0-9]+)\s*
+           (?P<left2sign1>[+-])\s*(?P<left2sign2>[+-]\s*)?(?P<left2>[0-9]+)\s*
+           (?P<top2sign1>[+-])\s*(?P<top2sign2>[+-]\s*)?(?P<top2>[0-9]+))
         )\s*$""",
         coordinates,
     )
     if match_res is None:
         msg = f"Coordinates syntax: {_COORDINATES_SYNTAX}"
         raise ValueError(msg)
+
     if match_res["top1"] is not None:
-        return (int(match_res["top1"]), int(match_res["left1"]), int(match_res["width1"]), int(match_res["height1"]))
+        return _CoordsWithEdges(
+            top=int(match_res["top1"]),
+            left=int(match_res["left1"]),
+            width=int(match_res["width1"]),
+            height=int(match_res["height1"]),
+            from_bottom=False,
+            from_right=False,
+        )
+
     if match_res["top2"] is not None:
-        top2 = int(match_res["top2"])
-        if match_res["top2sign"] == "-":
-            top2 = -top2
-        left2 = int(match_res["left2"])
-        if match_res["left2sign"] == "-":
-            left2 = -left2
-        return top2, left2, int(match_res["width2"]), int(match_res["height2"])
+        left, from_right = _parse_xgeom_coordinate(match_res["left2sign1"], match_res["left2sign2"], match_res["left2"])
+        top, from_bottom = _parse_xgeom_coordinate(match_res["top2sign1"], match_res["top2sign2"], match_res["top2"])
+        return _CoordsWithEdges(
+            top=top,
+            left=left,
+            width=int(match_res["width2"]),
+            height=int(match_res["height2"]),
+            from_bottom=from_bottom,
+            from_right=from_right,
+        )
+
     msg = f"Coordinates syntax: {_COORDINATES_SYNTAX}"
     raise ValueError(msg)
 
@@ -87,10 +165,7 @@ def _build_parser() -> ArgumentParser:
         "--coordinates",
         default="",
         type=str,
-        help=(
-            "the part of the screen to capture: TOP,LEFT,WIDTH,HEIGHT or WIDTHxHEIGHT+LEFT+TOP; "
-            "negative TOP or LEFT are insets from the bottom or right edge"
-        ),
+        help="the part of the screen to capture: TOP,LEFT,WIDTH,HEIGHT or WIDTHxHEIGHT+LEFT+TOP",
     )
     cli_args.add_argument(
         "-l",
@@ -117,20 +192,14 @@ def _build_parser() -> ArgumentParser:
     return cli_args
 
 
-def _prepare_grab_options(options: Namespace) -> tuple[int, str, dict[str, int] | None]:
+def _prepare_grab_options(options: Namespace) -> tuple[int, str, _CoordsWithEdges | None]:
     """Build grab options derived from parsed CLI arguments."""
     monitor_index = int(options.monitor)
     output_template = str(options.output)
-    if not options.coordinates:
+    if options.coordinates is None:
         return monitor_index, output_template, None
 
-    top, left, width, height = _parse_coordinates(str(options.coordinates))
-    coordinates = {
-        "top": int(top),
-        "left": int(left),
-        "width": int(width),
-        "height": int(height),
-    }
+    coordinates = _parse_coordinates(str(options.coordinates))
     if options.output == "monitor-{mon}.png":
         output_template = "sct-{top}x{left}_{width}x{height}.png"
     return monitor_index, output_template, coordinates
@@ -144,22 +213,53 @@ def _build_mss_kwargs(options: Namespace) -> dict[str, Any]:
     return mss_kwargs
 
 
+def _normalize_capture_region(coordinates: _CoordsWithEdges, reference: Monitor, bounds: Monitor) -> Monitor:
+    print(coordinates)
+    print(reference)
+    print(bounds)
+
+    if coordinates.from_bottom:
+        top = reference["top"] + reference["height"] - coordinates.top - coordinates.height
+    else:
+        top = reference["top"] + coordinates.top
+    if coordinates.from_right:
+        left = reference["left"] + reference["width"] - coordinates.left - coordinates.width
+    else:
+        left = reference["left"] + coordinates.left
+
+    # It's easier to crop to the bounds if we work on bottom and right.
+    bounds_bottom = bounds["top"] + bounds["height"]
+    bounds_right = bounds["left"] + bounds["width"]
+    bottom = min(top + coordinates.height, bounds_bottom)
+    right = min(left + coordinates.width, bounds_right)
+    top = max(top, bounds["top"])
+    left = max(left, bounds["left"])
+
+    rv = {
+        "top": top,
+        "left": left,
+        "height": bottom - top,
+        "width": right - left,
+    }
+    print(rv)
+    return rv
+
+
 def _capture_and_save(
     sct: MSS,
     *,
     options: Namespace,
     monitor_index: int,
     output_template: str,
-    coordinates: dict[str, int] | None,
+    coordinates: _CoordsWithEdges | None,
 ) -> None:
     """Capture screenshots and write output files."""
     if coordinates is not None:
-        if coordinates["top"] < 0:
-            coordinates["top"] = sct.monitors[monitor_index]["height"] + coordinates["top"]
-        if coordinates["left"] < 0:
-            coordinates["left"] = sct.monitors[monitor_index]["width"] + coordinates["left"]
-        output = output_template.format(**coordinates)
-        sct_img = sct.grab(coordinates)
+        desktop = sct.monitors[0]
+        mon = sct.monitors[monitor_index]
+        capture_region = _normalize_capture_region(coordinates, sct.monitors[monitor_index], sct.monitors[0])
+        output = output_template.format(**capture_region)
+        sct_img = sct.grab(capture_region)
         to_png(sct_img.rgb, sct_img.size, level=options.level, output=output)
         if not options.quiet:
             print(os.path.realpath(output))

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -16,7 +16,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 import mss
-from mss.__main__ import _parse_coordinates
+from mss.__main__ import _normalize_capture_region, _parse_coordinates
 from mss.__main__ import main as entry_point
 from mss.base import MSS, MSSImplementation
 from mss.exception import ScreenShotError
@@ -298,17 +298,17 @@ def test_entry_point_with_no_argument(capsys: pytest.CaptureFixture) -> None:
 @pytest.mark.parametrize(
     ("coordinates", "expected"),
     [
-        pytest.param(" 15,14,0012,13 ", (15, 14, 12, 13), id="comma_pos_top_pos_left"),
-        pytest.param("-15, 0014,12,0013", (-15, 14, 12, 13), id="comma_neg_top_pos_left"),
-        pytest.param("0015 , -14 , 12 , 13", (15, -14, 12, 13), id="comma_pos_top_neg_left"),
-        pytest.param(" -0015,-14,12,0013  ", (-15, -14, 12, 13), id="comma_neg_top_neg_left"),
-        pytest.param("12x13+14+15", (15, 14, 12, 13), id="x_pos_top_pos_left"),
-        pytest.param(" 0012 x 13 - 14 + 15 ", (15, -14, 12, 13), id="x_pos_top_neg_left"),
-        pytest.param("12x0013+0014-15", (-15, 14, 12, 13), id="x_neg_top_pos_left"),
-        pytest.param(" 12 x 13 - 0014 - 0015 ", (-15, -14, 12, 13), id="x_neg_top_neg_left"),
+        pytest.param(" 15,14,0012,13 ", (15, 14, 12, 13, False, False), id="comma_pos_top_pos_left"),
+        pytest.param("-15, 0014,12,0013", (-15, 14, 12, 13, False, False), id="comma_neg_top_pos_left"),
+        pytest.param("0015 , -14 , 12 , 13", (15, -14, 12, 13, False, False), id="comma_pos_top_neg_left"),
+        pytest.param(" -0015,-14,12,0013  ", (-15, -14, 12, 13, False, False), id="comma_neg_top_neg_left"),
+        pytest.param("12x13+14+15", (15, 14, 12, 13, False, False), id="x_pos_top_pos_left"),
+        pytest.param(" 0012 x 13 - 14 + 15 ", (15, 14, 12, 13, False, True), id="x_pos_top_neg_left"),
+        pytest.param("12x0013+0014-15", (15, 14, 12, 13, True, False), id="x_neg_top_pos_left"),
+        pytest.param(" 12 x 13 - 0014 - 0015 ", (15, 14, 12, 13, True, True), id="x_neg_top_neg_left"),
     ],
 )
-def test_parse_coordinates_valid(coordinates: str, expected: tuple[int, int, int, int]) -> None:
+def test_parse_coordinates_valid(coordinates: str, expected: tuple[int, int, int, int, bool, bool]) -> None:
     assert _parse_coordinates(coordinates) == expected
 
 
@@ -326,6 +326,58 @@ def test_parse_coordinates_valid(coordinates: str, expected: tuple[int, int, int
 def test_parse_coordinates_invalid(coordinates: str) -> None:
     with pytest.raises(ValueError, match=r"(?i)coordinates syntax"):
         _parse_coordinates(coordinates)
+
+
+# This is an exhaustive list of all the possible variations of
+# 100x100+-25+-25, where each "+-" is +, -, +-, -+, ++, or --.  Also,
+# the correct parse when used on a single 640x480 monitor is given,
+# including bounds cropping.
+@pytest.mark.parametrize(
+    ("geom", "expected"),
+    [
+        ("100x100+25+25", {"top": 25, "left": 25, "height": 100, "width": 100}),
+        ("100x100+25-25", {"top": 355, "left": 25, "height": 100, "width": 100}),
+        ("100x100+25++25", {"top": 25, "left": 25, "height": 100, "width": 100}),
+        ("100x100+25+-25", {"top": 0, "left": 25, "height": 75, "width": 100}),
+        ("100x100+25-+25", {"top": 355, "left": 25, "height": 100, "width": 100}),
+        ("100x100+25--25", {"top": 405, "left": 25, "height": 75, "width": 100}),
+        ("100x100-25+25", {"top": 25, "left": 515, "height": 100, "width": 100}),
+        ("100x100-25-25", {"top": 355, "left": 515, "height": 100, "width": 100}),
+        ("100x100-25++25", {"top": 25, "left": 515, "height": 100, "width": 100}),
+        ("100x100-25+-25", {"top": 0, "left": 515, "height": 75, "width": 100}),
+        ("100x100-25-+25", {"top": 355, "left": 515, "height": 100, "width": 100}),
+        ("100x100-25--25", {"top": 405, "left": 515, "height": 75, "width": 100}),
+        ("100x100++25+25", {"top": 25, "left": 25, "height": 100, "width": 100}),
+        ("100x100++25-25", {"top": 355, "left": 25, "height": 100, "width": 100}),
+        ("100x100++25++25", {"top": 25, "left": 25, "height": 100, "width": 100}),
+        ("100x100++25+-25", {"top": 0, "left": 25, "height": 75, "width": 100}),
+        ("100x100++25-+25", {"top": 355, "left": 25, "height": 100, "width": 100}),
+        ("100x100++25--25", {"top": 405, "left": 25, "height": 75, "width": 100}),
+        ("100x100+-25+25", {"top": 25, "left": 0, "height": 100, "width": 75}),
+        ("100x100+-25-25", {"top": 355, "left": 0, "height": 100, "width": 75}),
+        ("100x100+-25++25", {"top": 25, "left": 0, "height": 100, "width": 75}),
+        ("100x100+-25+-25", {"top": 0, "left": 0, "height": 75, "width": 75}),
+        ("100x100+-25-+25", {"top": 355, "left": 0, "height": 100, "width": 75}),
+        ("100x100+-25--25", {"top": 405, "left": 0, "height": 75, "width": 75}),
+        ("100x100-+25+25", {"top": 25, "left": 515, "height": 100, "width": 100}),
+        ("100x100-+25-25", {"top": 355, "left": 515, "height": 100, "width": 100}),
+        ("100x100-+25++25", {"top": 25, "left": 515, "height": 100, "width": 100}),
+        ("100x100-+25+-25", {"top": 0, "left": 515, "height": 75, "width": 100}),
+        ("100x100-+25-+25", {"top": 355, "left": 515, "height": 100, "width": 100}),
+        ("100x100-+25--25", {"top": 405, "left": 515, "height": 75, "width": 100}),
+        ("100x100--25+25", {"top": 25, "left": 565, "height": 100, "width": 75}),
+        ("100x100--25-25", {"top": 355, "left": 565, "height": 100, "width": 75}),
+        ("100x100--25++25", {"top": 25, "left": 565, "height": 100, "width": 75}),
+        ("100x100--25+-25", {"top": 0, "left": 565, "height": 75, "width": 75}),
+        ("100x100--25-+25", {"top": 355, "left": 565, "height": 100, "width": 75}),
+        ("100x100--25--25", {"top": 405, "left": 565, "height": 75, "width": 75}),
+    ],
+)
+def test_parse_coordinates_negative_exhaustive(geom: str, expected: Monitor) -> None:
+    mon = {"top": 0, "left": 0, "width": 640, "height": 480}
+    parsed = _parse_coordinates(geom)
+    norm = _normalize_capture_region(parsed, mon, mon)
+    assert norm == expected
 
 
 def test_grab_with_tuple(mss_impl: Callable[..., MSS]) -> None:

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -306,6 +306,12 @@ def test_entry_point_with_no_argument(capsys: pytest.CaptureFixture) -> None:
         pytest.param(" 0012 x 13 - 14 + 15 ", (15, 14, 12, 13, False, True), id="x_pos_top_neg_left"),
         pytest.param("12x0013+0014-15", (15, 14, 12, 13, True, False), id="x_neg_top_pos_left"),
         pytest.param(" 12 x 13 - 0014 - 0015 ", (15, 14, 12, 13, True, True), id="x_neg_top_neg_left"),
+        pytest.param("12x13-+14+15", (15, 14, 12, 13, False, True), id="x_rel_12x13-+14+15"),
+        pytest.param("12x13+-14++15", (15, -14, 12, 13, False, False), id="x_rel_12x13+-14++15"),
+        pytest.param("12x13++14-15", (15, 14, 12, 13, True, False), id="x_rel_12x13++14-15"),
+        pytest.param("12x13-14-+15", (15, 14, 12, 13, True, True), id="x_rel_12x13-14-+15"),
+        pytest.param("12x13--14+-15", (-15, -14, 12, 13, False, True), id="x_rel_12x13--14+-15"),
+        pytest.param("12x13+14--15", (-15, 14, 12, 13, True, False), id="x_rel_12x13+14--15"),
     ],
 )
 def test_parse_coordinates_valid(coordinates: str, expected: tuple[int, int, int, int, bool, bool]) -> None:
@@ -328,10 +334,6 @@ def test_parse_coordinates_invalid(coordinates: str) -> None:
         _parse_coordinates(coordinates)
 
 
-# This is an exhaustive list of all the possible variations of
-# 100x100+-25+-25, where each "+-" is +, -, +-, -+, ++, or --.  Also,
-# the correct parse when used on a single 640x480 monitor is given,
-# including bounds cropping.
 @pytest.mark.parametrize(
     ("geom", "expected"),
     [
@@ -341,39 +343,9 @@ def test_parse_coordinates_invalid(coordinates: str) -> None:
         ("100x100+25+-25", {"top": 0, "left": 25, "height": 75, "width": 100}),
         ("100x100+25-+25", {"top": 355, "left": 25, "height": 100, "width": 100}),
         ("100x100+25--25", {"top": 405, "left": 25, "height": 75, "width": 100}),
-        ("100x100-25+25", {"top": 25, "left": 515, "height": 100, "width": 100}),
-        ("100x100-25-25", {"top": 355, "left": 515, "height": 100, "width": 100}),
-        ("100x100-25++25", {"top": 25, "left": 515, "height": 100, "width": 100}),
-        ("100x100-25+-25", {"top": 0, "left": 515, "height": 75, "width": 100}),
-        ("100x100-25-+25", {"top": 355, "left": 515, "height": 100, "width": 100}),
-        ("100x100-25--25", {"top": 405, "left": 515, "height": 75, "width": 100}),
-        ("100x100++25+25", {"top": 25, "left": 25, "height": 100, "width": 100}),
-        ("100x100++25-25", {"top": 355, "left": 25, "height": 100, "width": 100}),
-        ("100x100++25++25", {"top": 25, "left": 25, "height": 100, "width": 100}),
-        ("100x100++25+-25", {"top": 0, "left": 25, "height": 75, "width": 100}),
-        ("100x100++25-+25", {"top": 355, "left": 25, "height": 100, "width": 100}),
-        ("100x100++25--25", {"top": 405, "left": 25, "height": 75, "width": 100}),
-        ("100x100+-25+25", {"top": 25, "left": 0, "height": 100, "width": 75}),
-        ("100x100+-25-25", {"top": 355, "left": 0, "height": 100, "width": 75}),
-        ("100x100+-25++25", {"top": 25, "left": 0, "height": 100, "width": 75}),
-        ("100x100+-25+-25", {"top": 0, "left": 0, "height": 75, "width": 75}),
-        ("100x100+-25-+25", {"top": 355, "left": 0, "height": 100, "width": 75}),
-        ("100x100+-25--25", {"top": 405, "left": 0, "height": 75, "width": 75}),
-        ("100x100-+25+25", {"top": 25, "left": 515, "height": 100, "width": 100}),
-        ("100x100-+25-25", {"top": 355, "left": 515, "height": 100, "width": 100}),
-        ("100x100-+25++25", {"top": 25, "left": 515, "height": 100, "width": 100}),
-        ("100x100-+25+-25", {"top": 0, "left": 515, "height": 75, "width": 100}),
-        ("100x100-+25-+25", {"top": 355, "left": 515, "height": 100, "width": 100}),
-        ("100x100-+25--25", {"top": 405, "left": 515, "height": 75, "width": 100}),
-        ("100x100--25+25", {"top": 25, "left": 565, "height": 100, "width": 75}),
-        ("100x100--25-25", {"top": 355, "left": 565, "height": 100, "width": 75}),
-        ("100x100--25++25", {"top": 25, "left": 565, "height": 100, "width": 75}),
-        ("100x100--25+-25", {"top": 0, "left": 565, "height": 75, "width": 75}),
-        ("100x100--25-+25", {"top": 355, "left": 565, "height": 100, "width": 75}),
-        ("100x100--25--25", {"top": 405, "left": 565, "height": 75, "width": 75}),
     ],
 )
-def test_parse_coordinates_negative_exhaustive(geom: str, expected: Monitor) -> None:
+def test_parse_and_normalize_coordinates(geom: str, expected: Monitor) -> None:
     mon = {"top": 0, "left": 0, "width": 640, "height": 480}
     parsed = _parse_coordinates(geom)
     norm = _normalize_capture_region(parsed, mon, mon)

--- a/src/tests/test_implementation.py
+++ b/src/tests/test_implementation.py
@@ -337,18 +337,18 @@ def test_parse_coordinates_invalid(coordinates: str) -> None:
 @pytest.mark.parametrize(
     ("geom", "expected"),
     [
-        ("100x100+25+25", {"top": 25, "left": 25, "height": 100, "width": 100}),
-        ("100x100+25-25", {"top": 355, "left": 25, "height": 100, "width": 100}),
-        ("100x100+25++25", {"top": 25, "left": 25, "height": 100, "width": 100}),
-        ("100x100+25+-25", {"top": 0, "left": 25, "height": 75, "width": 100}),
-        ("100x100+25-+25", {"top": 355, "left": 25, "height": 100, "width": 100}),
-        ("100x100+25--25", {"top": 405, "left": 25, "height": 75, "width": 100}),
+        pytest.param("100x100+25+25", {"top": 25, "left": 25, "height": 100, "width": 100}, id="+25"),
+        pytest.param("100x100+25-25", {"top": 355, "left": 25, "height": 100, "width": 100}, id="-25"),
+        pytest.param("100x100+25++25", {"top": 25, "left": 25, "height": 100, "width": 100}, id="++25"),
+        pytest.param("100x100+25+-25", {"top": -25, "left": 25, "height": 100, "width": 100}, id="+-25"),
+        pytest.param("100x100+25-+25", {"top": 355, "left": 25, "height": 100, "width": 100}, id="-+25"),
+        pytest.param("100x100+25--25", {"top": 405, "left": 25, "height": 100, "width": 100}, id="--25"),
     ],
 )
 def test_parse_and_normalize_coordinates(geom: str, expected: Monitor) -> None:
     mon = {"top": 0, "left": 0, "width": 640, "height": 480}
     parsed = _parse_coordinates(geom)
-    norm = _normalize_capture_region(parsed, mon, mon)
+    norm = _normalize_capture_region(parsed, mon)
     assert norm == expected
 
 


### PR DESCRIPTION
### Changes proposed in this PR

In #562, I had misinterpreted how negative numbers in X geometry strings are handled.  As a result of this, I also broke the ability to pass negative top and left coordinates, which are valid on Windows and macOS.

This fixes the negative numbers to be consistent with XParseGeometry, and restores the ability to have negative top and left coordinates in both styles.

- [X] Tests added/updated
- [X] Documentation updated
- [ ] Changelog entry added - N/A
- [X] `./check.sh` passed

### AI assistance disclosure

- [X] No AI assistance was used to generate this contribution.
