### PR TITLE
Use Xvfb for the entire test session, if possible.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,13 +106,8 @@ jobs:
         if: contains(fromJSON('["3.10", "3.11", "3.12"]'), matrix.python.runs-on)
         run: python -m pip install tensorflow
 
-      - name: Tests (GNU/Linux)
+      - name: Tests
         timeout-minutes: 10
-        if: matrix.os.name == 'linux'
-        run: xvfb-run python -m pytest
-      - name: Tests (macOS, Windows)
-        timeout-minutes: 10
-        if: matrix.os.name != 'linux'
         run: python -m pytest
 
   automerge:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,12 +51,6 @@ When adding, removing, or renaming a packaged file, update the explicit expected
 python -m pytest src/tests/test_setup.py::test_sdist src/tests/test_setup.py::test_wheel
 ```
 
-On headless GNU/Linux environments, run tests with a virtual display:
-
-```shell
-xvfb-run python -m pytest
-```
-
 When documentation changes, install docs dependencies and build docs with warnings as errors:
 
 ```shell

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -3,6 +3,7 @@ Source: https://github.com/BoboTiG/python-mss.
 """
 
 import os
+import shutil
 from collections.abc import Callable, Generator
 from hashlib import sha256
 from pathlib import Path
@@ -14,6 +15,14 @@ import pytest
 
 from mss import MSS
 from mss.linux import xcb, xlib
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--no-virtual-display",
+        action="store_true",
+        help="Do not run all the tests under Xvfb",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -89,8 +98,41 @@ def mss_impl(backend: str) -> Callable[..., MSS]:
     return impl
 
 
-@pytest.fixture(autouse=True, scope="session")
-def inhibit_x11_resets() -> Generator[None, None, None]:
+@pytest.fixture(scope="session", autouse=True)
+def virtual_display(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    """Use Xvnc for the test session, if feasible.
+
+    This isolates the testing from the development display.  This is
+    necessary to test X backends under Wayland (XWayland doesn't allow
+    programs to capture the root window), to avoid annoying the
+    developer with transient windows during testing, and to avoid
+    problems with the screen changing during tests that expect
+    successive screenshots to be identical.
+
+    If Xvfb and pyvirtualdisplay are not available, then the current
+    display is used as a fallback.
+    """
+    if system() != "Linux" or request.config.getoption("--no-virtual-display") or shutil.which("Xvfb") is None:
+        yield
+        return
+
+    try:
+        from pyvirtualdisplay import Display  # noqa: PLC0415
+    except ImportError:
+        yield
+        return
+
+    # We use 1280x1024 since test_issue_220 requires it.  The default for pyvirtualdisplay is manage_global_env=True,
+    # but we make it explicit here to forestall future changes.  We use MonkeyPatch to make sure that nothing tries to
+    # use Wayland, which would bypass $DISPLAY.
+    with Display(size=(1280, 1024), manage_global_env=True), pytest.MonkeyPatch.context() as mp:
+        mp.delenv("WAYLAND_DISPLAY", raising=False)
+        mp.delenv("XDG_SESSION_TYPE", raising=False)
+        yield
+
+
+@pytest.fixture(scope="session", autouse=True)
+def inhibit_x11_resets(virtual_display: None) -> Generator[None, None, None]:  # noqa: ARG001 virtual_display is for ordering
     """Ensure that an X11 connection is open during the test session.
 
     Under X11, when the last client disconnects, the server resets.  If


### PR DESCRIPTION
This eliminates the need to explicitly use xvfb-run while running tests, which can be an annoying extra step.

Using Xvfb avoids three problems:

1. It allows testing of the X11 backends if the developer is using Wayland.  XWayland doesn't allow capturing the root window, so Xvfb is necessary.
2. If the developer's screen is changing during testing, such as if they have PyTest running in a terminal, this can disrupt the tests that take consecutive screenshots and expect them to be identical. Using an isolated Xvfb avoids this problem.
3. It stops annoying the user with transient windows created by some tests.

On platforms other than Linux, or if Xvfb or pyvirtualdisplay are not available, or the developer specifies --no-virtual-display, then Xvfb is not run session-wide.  (Some tests may still create it for individual tests.)

This does not affect the tests that run their own Xvfb sessions, such as to test different color depths or missing MIT-SHM support.

### Changes proposed in this PR

- [X] Tests added/updated
- [ ] Documentation updated - N/A (I thought there was a reference to using xvfb-run in the docs, but couldn't find one.  I did change the reference in AGENTS.md.)
- [ ] Changelog entry added - N/A (not user-facing)
- [X] `./check.sh` passed

### AI assistance disclosure

- [ ] No AI assistance was used to generate this contribution. - Used AI