### PR TITLE
Delete temporary .png files created by tests

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -2,8 +2,10 @@
 Source: https://github.com/BoboTiG/python-mss.
 """
 
+import operator
 import os
 from collections.abc import Callable, Generator
+from functools import reduce
 from hashlib import sha256
 from pathlib import Path
 from platform import system
@@ -27,20 +29,24 @@ def _no_warnings(recwarn: pytest.WarningsRecorder) -> Generator:
     assert not warnings
 
 
-def purge_files() -> None:
-    """Remove all generated files from previous runs."""
-    for file in Path().glob("*.png"):
-        print(f"Deleting {file} ...")
-        file.unlink()
-
-    for file in Path().glob("*.png.old"):
-        print(f"Deleting {file} ...")
-        file.unlink()
+_PURGE_GLOBS = {"*.png", "*.png.old"}
 
 
 @pytest.fixture(scope="module", autouse=True)
-def _before_tests() -> None:
-    purge_files()
+def purge_files() -> Generator[None]:
+    """Remove any .png or .png.old files created during the test module.
+
+    This is useful for tests that generate screenshots, so that they
+    don't accumulate in the source tree and pollute the results of
+    future test runs.
+    """
+    before_images = reduce(operator.or_, (set(Path().glob(g)) for g in _PURGE_GLOBS))
+    yield
+    after_images = reduce(operator.or_, (set(Path().glob(g)) for g in _PURGE_GLOBS))
+    new_images = after_images - before_images
+    for file in new_images:
+        print(f"Deleting {file} ...")
+        file.unlink()
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
The previous behavior would remove any `*.png` or `*.png.old` files in the current directory, including those that were not created by the tests.  This might include files that the developer has for other purposes.  The previous behavior also only did this before running tests, not after.

This commit modifies the cleanup code to only remove new `.png` (and `.png.old`) files that were created by the tests, and to do so immediately after the tests have run.

In the future, we would probably be better off creating our PNG files in a directory managed by the [PyTest tmp_path fixture](https://docs.pytest.org/en/stable/how-to/tmp_path.html).  To that end, this change also is a step towards reliably identifying which tests are creating PNG files.

### Changes proposed in this PR

- [X] Tests added/updated
- [ ] Documentation updated - N/A
- [ ] Changelog entry added - N/A
- [X] `./check.sh` passed

### AI assistance disclosure

- [ ] No AI assistance was used to generate this contribution. - AI autocomplete generated some completions that were used.