### PR TITLE
Improve PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,12 @@
-### Changes proposed in this PR
-
 Fixes #
-(...)
 
-- [ ] Tests added/updated
-- [ ] Documentation updated
-- [ ] Changelog entry added
-- [ ] `./check.sh` passed
+<!-- Briefly describe what changed and why. -->
+
+- [ ] Tests added/updated (or your review concluded: not needed)
+- [ ] Documentation updated (or your review concluded: not needed)
+- [ ] Release notes added (or your review concluded: not needed)
+- [ ] `./check.sh` (or `./check.ps1`) passed
 
 ### AI assistance disclosure
 
-- [ ] No AI assistance was used to generate this contribution.
+- AI was not / partially / entirely (choose one) used to create this change.


### PR DESCRIPTION
There are a few goals with this change, and I list them below. Please suggest tweaks or better wording. English is my third language 😄

* Make the PR template simpler
  - remove the heading because every PR has a Title that is outside this template
  - instead of the "open to interpretation" `(...)` we now have a markdown comment that tells contributors what we expect
* Make the template reflect our new reality
  - we now have release notes instead of a changelog. We probably need more docs about how contributors are expected to update the release notes. Maybe those guides exist and I just couldn't find them (would be nice to link to a guide)
* Drive contributors to take action on all items
  - before they would only check if a test was added/update, etc but this makes the GitHub interface look odd because a PR will show as having incomplete tasks.
  - similarly, with the changed wording for AI disclosure we can tell if people took action there or not. If someone doesn't disclose we will assume AI was at least partially involved.
 
 [x] Tests added/updated (or your review concluded: not needed)
 [x] Documentation updated (or your review concluded: not needed)
 [x] Release notes added (or your review concluded: not needed)
 [x] `./check.sh` (or `./check.ps1`) passed

### AI assistance disclosure

AI was not used to create this change.